### PR TITLE
Port Flash Message component with Stimulus auto-registration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,9 @@ GEM
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -313,6 +316,7 @@ DEPENDENCIES
   rubocop-rails
   simplecov
   sqlite3
+  turbo-rails
 
 CHECKSUMS
   action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
@@ -413,6 +417,7 @@ CHECKSUMS
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ bundle install
 rails generate jet_ui:install
 ```
 
-The generator detects your Tailwind CSS source file and injects a single import that covers all component stylesheets. When the gem is updated with new components, your app picks them up automatically on the next CSS build — no manual changes needed.
+The generator:
+- Detects your Tailwind CSS source file and injects a single import covering all component stylesheets
+- Registers JetUi Stimulus controllers in your app's controllers index
+
+When the gem is updated, both CSS and JS are picked up automatically — no further changes needed. Safe to re-run after upgrades.
 
 ## Usage
 
@@ -65,12 +69,15 @@ Subcomponents follow the `namespace_subcomponent` naming convention (`card_heade
 | Stepper | [docs/components/stepper.md](docs/components/stepper.md) |
 | Table | [docs/components/table.md](docs/components/table.md) |
 | Pagy | [docs/components/pagy.md](docs/components/pagy.md) |
+| Flash ⚡ | [docs/components/flash.md](docs/components/flash.md) |
+
+⚡ Requires Stimulus (configured automatically by `jet_ui:install`).
 
 ## Generators
 
 ### `jet_ui:install`
 
-Sets up JetUi in your application:
+Sets up JetUi in your application (CSS + JS). Safe to re-run after gem upgrades — already-configured steps are skipped:
 
 ```bash
 rails generate jet_ui:install
@@ -78,12 +85,12 @@ rails generate jet_ui:install
 
 ### `jet_ui:eject`
 
-Copies a component's source files into your application for local customisation. Ejected files take precedence over the gem's versions automatically.
+Copies a component's source files into your application for local customisation. Ejected files take precedence over the gem's versions automatically. For components with a Stimulus controller (e.g. `flash`), the JS file is ejected too.
 
 ```bash
 rails generate jet_ui:eject btn
-rails generate jet_ui:eject card
-rails generate jet_ui:eject btn card
+rails generate jet_ui:eject flash
+rails generate jet_ui:eject btn card flash
 ```
 
 By default both the test file and the ViewComponent preview are ejected. Use the flags below to skip either:

--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ rails generate jet_ui:eject flash
 rails generate jet_ui:eject btn card flash
 ```
 
-By default both the test file and the ViewComponent preview are ejected. Use the flags below to skip either:
+By default the test, preview, and JS controller (when present) are all ejected. Use flags to skip any of them:
 
 ```bash
 rails generate jet_ui:eject btn --skip-test
 rails generate jet_ui:eject btn --skip-preview
+rails generate jet_ui:eject flash --skip-javascript
 rails generate jet_ui:eject btn --skip-test --skip-preview
 ```

--- a/app/assets/javascripts/jet_ui/flash_controller.js
+++ b/app/assets/javascripts/jet_ui/flash_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class FlashController extends Controller {
+  static values = {
+    dismissAfter: Number,
+    showDelay: { type: Number, default: 0 }
+  }
+
+  connect() {
+    setTimeout(() => this.#show(), this.showDelayValue)
+
+    if (this.hasDismissAfterValue) {
+      setTimeout(() => this.close(), this.showDelayValue + this.dismissAfterValue)
+    }
+  }
+
+  close() {
+    this.element.classList.remove("flash-item--visible")
+    const fallback = setTimeout(() => this.element.remove(), 400)
+    this.element.addEventListener("transitionend", () => {
+      clearTimeout(fallback)
+      this.element.remove()
+    }, { once: true })
+  }
+
+  #show() {
+    this.element.classList.remove("flash-item--hidden")
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.element.classList.add("flash-item--visible")
+      })
+    })
+  }
+}

--- a/app/assets/stylesheets/jet_ui.css
+++ b/app/assets/stylesheets/jet_ui.css
@@ -16,3 +16,4 @@
 @import "./jet_ui/stepper.css";
 @import "./jet_ui/table.css";
 @import "./jet_ui/pagy.css";
+@import "./jet_ui/flash.css";

--- a/app/assets/stylesheets/jet_ui/flash.css
+++ b/app/assets/stylesheets/jet_ui/flash.css
@@ -1,0 +1,50 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .flash-container {
+    @apply fixed flex flex-col items-end gap-2 top-3 left-3 right-3 z-[100];
+    @apply md:left-auto md:w-fit;
+  }
+
+  .flash-item {
+    @apply relative w-full py-3 pl-4 pr-12 text-sm rounded-xl text-white;
+    @apply md:max-w-lg md:w-fit;
+    min-width: 20rem;
+    opacity: 0;
+    transform: translateX(25%);
+    transition: opacity 300ms, transform 300ms;
+  }
+
+  .flash-item--hidden {
+    display: none;
+  }
+
+  .flash-item--visible {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  .flash-item-info {
+    background-color: var(--color-info);
+  }
+
+  .flash-item-success {
+    background-color: var(--color-success);
+  }
+
+  .flash-item-warning {
+    background-color: var(--color-warning);
+  }
+
+  .flash-item-error {
+    background-color: var(--color-destructive);
+  }
+
+  .flash-item__message {
+    @apply flex-1;
+  }
+
+  .flash-item__close {
+    @apply absolute top-2.5 right-3 text-white transition duration-300 focus:outline-none opacity-80 hover:opacity-100;
+  }
+}

--- a/app/components/jet_ui/flash/component.html.erb
+++ b/app/components/jet_ui/flash/component.html.erb
@@ -1,0 +1,14 @@
+<%= helpers.turbo_frame_tag @frame_id, class: 'flash-container', target: :_top, refresh: :morph do %>
+  <% flash_messages.each do |key, message| %>
+    <% next if message.blank? %>
+
+    <%= content_tag :div, id: "flash-#{key}", class: item_class(key), data: item_data do %>
+      <p class="flash-item__message"><%= message.html_safe %></p>
+      <% if @dismissible %>
+        <button class="flash-item__close" type="button" data-action="flash#close" aria-label="Close">
+          <%= render(JetUi::Icon::Component.new('x-mark', size: 5)) %>
+        </button>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/jet_ui/flash/component.rb
+++ b/app/components/jet_ui/flash/component.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Flash
+    class Component < BaseComponent
+      DISMISS_AFTER = 5000
+      SHOW_DELAY    = 250
+
+      TYPE_CLASSES = {
+        'notice' => 'flash-item-info',
+        'success' => 'flash-item-success',
+        'alert' => 'flash-item-error',
+        'error' => 'flash-item-error',
+        'warning' => 'flash-item-warning'
+      }.freeze
+
+      def initialize(messages: nil, dismissible: true, frame_id: :flash)
+        @messages    = messages
+        @dismissible = dismissible
+        @frame_id    = frame_id
+      end
+
+      private
+
+      def flash_messages
+        @messages || flash
+      end
+
+      def item_class(flash_type)
+        type_class = TYPE_CLASSES[flash_type.to_s] || "flash-item-#{flash_type}"
+        class_names('flash-item', 'flash-item--hidden', type_class)
+      end
+
+      def item_data
+        attrs = { controller: 'flash', action: 'turbo:morph@window->flash#connect' }
+        if @dismissible
+          attrs[:flash_dismiss_after_value] = DISMISS_AFTER
+          attrs[:flash_show_delay_value]    = SHOW_DELAY
+        end
+        attrs
+      end
+    end
+  end
+end

--- a/docs/components/flash.md
+++ b/docs/components/flash.md
@@ -1,0 +1,76 @@
+# Flash
+
+Toast-style notification component that displays Rails flash messages. Messages animate in from the right, auto-dismiss after 5 seconds, and can be manually closed.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Usage
+
+Add to your application layout:
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+<%= jet_ui.flash(messages: flash) %>
+```
+
+Flash messages set in your controllers appear automatically:
+
+```ruby
+flash[:notice]  = "Changes saved successfully."
+flash[:success] = "Account created."
+flash[:alert]   = "Something went wrong."
+flash[:warning] = "Session will expire soon."
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `messages` | Hash / nil | `nil` | Flash messages hash. Defaults to the view's `flash` helper when not provided. |
+| `dismissible` | Boolean | `true` | Shows close button and auto-dismisses after 5 seconds. |
+| `frame_id` | Symbol | `:flash` | Turbo frame ID. Override when rendering multiple instances on one page (e.g. demos). |
+
+## Message types
+
+| Key | Style |
+|-----|-------|
+| `notice` | Info (blue) |
+| `success` | Success (green) |
+| `warning` | Warning (yellow) |
+| `alert` | Error (red) |
+| `error` | Error (red) |
+| Any other key | Uses `flash-item-{key}` class — style it yourself |
+
+## Non-dismissible
+
+```erb
+<%= jet_ui.flash(messages: flash, dismissible: false) %>
+```
+
+Messages render without a close button and do not auto-dismiss.
+
+## CSS classes
+
+| Class | Description |
+|-------|-------------|
+| `.flash-container` | Fixed positioned wrapper (top-right) |
+| `.flash-item` | Individual message element |
+| `.flash-item--hidden` | Initial hidden state (removed by JS on connect) |
+| `.flash-item--visible` | Visible state with CSS transition |
+| `.flash-item-info` | Info style (notice) |
+| `.flash-item-success` | Success style |
+| `.flash-item-warning` | Warning style |
+| `.flash-item-error` | Error style (alert / error) |
+| `.flash-item__message` | Message text paragraph |
+| `.flash-item__close` | Close button |
+
+## Stimulus controller
+
+The `flash` Stimulus controller handles show/hide animations. It is registered automatically via `eagerLoadControllersFrom("jet_ui", application)` when you run `jet_ui:install`.
+
+Values used by the controller:
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dismissAfter` | Number | — | Ms before auto-dismiss. Only set when `dismissible: true`. |
+| `showDelay` | Number | `250` | Ms delay before the enter animation starts. |

--- a/jet_ui.gemspec
+++ b/jet_ui.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-minitest'
   spec.add_development_dependency 'rubocop-rails'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'turbo-rails'
 end

--- a/lib/generators/jet_ui/eject/USAGE
+++ b/lib/generators/jet_ui/eject/USAGE
@@ -3,9 +3,17 @@ Description:
     be customised locally. The ejected files take precedence over the gem's
     built-in versions, similar to how `rails generate devise:views` works.
 
-    Available components: btn, card
+    For components that include a Stimulus controller (e.g. flash), the JS
+    file is also ejected alongside the Ruby and CSS files.
+
+    Available components:
+      btn, card, icon, spinner, avatar, breadcrumbs, tabs, empty, list,
+      divider, timeline, stepper, table, pagy, flash
 
 Examples:
     rails generate jet_ui:eject btn
-    rails generate jet_ui:eject card
-    rails generate jet_ui:eject btn card
+    rails generate jet_ui:eject flash
+    rails generate jet_ui:eject btn card flash
+    rails generate jet_ui:eject btn --skip-test
+    rails generate jet_ui:eject btn --skip-preview
+    rails generate jet_ui:eject btn --skip-test --skip-preview

--- a/lib/generators/jet_ui/eject/USAGE
+++ b/lib/generators/jet_ui/eject/USAGE
@@ -16,4 +16,5 @@ Examples:
     rails generate jet_ui:eject btn card flash
     rails generate jet_ui:eject btn --skip-test
     rails generate jet_ui:eject btn --skip-preview
+    rails generate jet_ui:eject flash --skip-javascript
     rails generate jet_ui:eject btn --skip-test --skip-preview

--- a/lib/generators/jet_ui/eject/eject_generator.rb
+++ b/lib/generators/jet_ui/eject/eject_generator.rb
@@ -14,7 +14,7 @@ module JetUi
         so they can be customised locally. Ejected files take precedence over
         the gem's built-in versions automatically — no extra configuration needed.
 
-        Available components: #{%w[btn card icon spinner avatar breadcrumbs tabs empty list divider timeline stepper table pagy].join(', ')}
+        Available components: #{%w[btn card icon spinner avatar breadcrumbs tabs empty list divider timeline stepper table pagy flash].join(', ')}
 
         Examples:
           rails generate jet_ui:eject btn
@@ -185,6 +185,16 @@ module JetUi
             { src: 'test/components/previews/jet_ui/divider/component_preview.rb',                                dest: 'test/components/previews/jet_ui/divider/component_preview.rb',          type: :preview },
             { src: 'test/components/previews/jet_ui/divider/component_preview/with_text.html.erb',                dest: 'test/components/previews/jet_ui/divider/component_preview/with_text.html.erb', type: :preview },
             { src: 'test/components/previews/jet_ui/divider/component_preview/aligned.html.erb',                  dest: 'test/components/previews/jet_ui/divider/component_preview/aligned.html.erb', type: :preview }
+          ]
+        },
+        'flash' => {
+          files: [
+            { src: 'app/components/jet_ui/flash/component.rb',                                                   dest: 'app/components/jet_ui/flash/component.rb' },
+            { src: 'app/components/jet_ui/flash/component.html.erb',                                             dest: 'app/components/jet_ui/flash/component.html.erb' },
+            { src: 'app/assets/stylesheets/jet_ui/flash.css',                                                    dest: 'app/assets/stylesheets/jet_ui/flash.css' },
+            { src: 'app/assets/javascripts/jet_ui/flash_controller.js',                                          dest: 'app/assets/javascripts/jet_ui/flash_controller.js' },
+            { src: 'test/components/jet_ui/flash/component_test.rb',                                             dest: 'test/components/jet_ui/flash/component_test.rb',                         type: :test },
+            { src: 'test/components/previews/jet_ui/flash/component_preview.rb',                                 dest: 'test/components/previews/jet_ui/flash/component_preview.rb',             type: :preview }
           ]
         },
         'list' => {

--- a/lib/generators/jet_ui/eject/eject_generator.rb
+++ b/lib/generators/jet_ui/eject/eject_generator.rb
@@ -18,11 +18,11 @@ module JetUi
 
         Examples:
           rails generate jet_ui:eject btn
-          rails generate jet_ui:eject card
-          rails generate jet_ui:eject icon
-          rails generate jet_ui:eject btn card
+          rails generate jet_ui:eject flash
+          rails generate jet_ui:eject btn card flash
           rails generate jet_ui:eject btn --skip-test
           rails generate jet_ui:eject btn --skip-preview
+          rails generate jet_ui:eject flash --skip-javascript
           rails generate jet_ui:eject btn --skip-test --skip-preview
       DESC
 
@@ -34,6 +34,9 @@ module JetUi
 
       class_option :skip_preview, type: :boolean, default: false,
                                   desc: 'Skip ejecting the ViewComponent preview file'
+
+      class_option :skip_javascript, type: :boolean, default: false,
+                                     desc: 'Skip ejecting the Stimulus controller JS file (for components that have one)'
 
       MANIFEST = {
         'btn' => {
@@ -192,7 +195,7 @@ module JetUi
             { src: 'app/components/jet_ui/flash/component.rb',                                                   dest: 'app/components/jet_ui/flash/component.rb' },
             { src: 'app/components/jet_ui/flash/component.html.erb',                                             dest: 'app/components/jet_ui/flash/component.html.erb' },
             { src: 'app/assets/stylesheets/jet_ui/flash.css',                                                    dest: 'app/assets/stylesheets/jet_ui/flash.css' },
-            { src: 'app/assets/javascripts/jet_ui/flash_controller.js',                                          dest: 'app/assets/javascripts/jet_ui/flash_controller.js' },
+            { src: 'app/assets/javascripts/jet_ui/flash_controller.js',                                          dest: 'app/assets/javascripts/jet_ui/flash_controller.js',                      type: :javascript },
             { src: 'test/components/jet_ui/flash/component_test.rb',                                             dest: 'test/components/jet_ui/flash/component_test.rb',                         type: :test },
             { src: 'test/components/previews/jet_ui/flash/component_preview.rb',                                 dest: 'test/components/previews/jet_ui/flash/component_preview.rb',             type: :preview }
           ]
@@ -224,8 +227,9 @@ module JetUi
         components.map(&:downcase).each do |name|
           say "\nEjecting #{name}...", :cyan
           MANIFEST[name][:files].each do |entry|
-            next if entry[:type] == :test    && options[:skip_test]
-            next if entry[:type] == :preview && options[:skip_preview]
+            next if entry[:type] == :test       && options[:skip_test]
+            next if entry[:type] == :preview    && options[:skip_preview]
+            next if entry[:type] == :javascript && options[:skip_javascript]
 
             copy_file entry[:src], entry[:dest]
           end
@@ -235,8 +239,9 @@ module JetUi
 
       def show_summary
         skipped = []
-        skipped << 'tests'    if options[:skip_test]
-        skipped << 'previews' if options[:skip_preview]
+        skipped << 'tests'      if options[:skip_test]
+        skipped << 'previews'   if options[:skip_preview]
+        skipped << 'javascript' if options[:skip_javascript]
 
         say "\nDone! Ejected: #{components.map(&:downcase).join(', ')}", :green
         say "  (skipped: #{skipped.join(', ')})" if skipped.any?

--- a/lib/generators/jet_ui/install/USAGE
+++ b/lib/generators/jet_ui/install/USAGE
@@ -1,9 +1,11 @@
 Description:
     Sets up JetUi in your Rails application.
 
-    - Injects `@import "jet_ui"` into your CSS entrypoint
-    - Shows Tailwind CSS content configuration hints
-    - Prints usage examples
+    - Injects the JetUi CSS import into your Tailwind entrypoint
+    - Registers JetUi Stimulus controllers via eagerLoadControllersFrom
+      (requires @hotwired/stimulus-loading, included in default Rails apps)
+
+    Safe to run multiple times — already-configured steps are skipped.
 
 Example:
     rails generate jet_ui:install

--- a/lib/generators/jet_ui/install/install_generator.rb
+++ b/lib/generators/jet_ui/install/install_generator.rb
@@ -14,10 +14,16 @@ module JetUi
       desc <<~DESC
         Sets up JetUi in your Rails application.
 
-        Detects your Tailwind CSS source file and injects a single @import
-        that covers all JetUi component stylesheets. When the gem is updated
-        with new components, your app picks them up automatically on the next
-        CSS build — no manual changes needed.
+        1. CSS — Detects your Tailwind source file and injects a single @import
+           that covers all JetUi component stylesheets. New components added in
+           future gem updates are picked up automatically on the next CSS build.
+
+        2. JS — Adds eagerLoadControllersFrom("jet_ui", application) to your
+           Stimulus controllers index. All current and future JetUi Stimulus
+           controllers (flash, modal, etc.) are registered automatically when
+           you update the gem — no further changes needed.
+
+        Safe to run multiple times — already-configured steps are skipped.
 
         Supported Tailwind source file locations:
           app/assets/tailwind/application.css
@@ -46,8 +52,29 @@ module JetUi
         end
       end
 
+      def inject_js
+        path = File.join(destination_root, JS_CONTROLLERS_FILE)
+        unless File.exist?(path)
+          say '  No Stimulus controllers index found — skipping JS setup.', :yellow
+          say '  If you use Stimulus, add this line to your controllers index manually:', :yellow
+          say %(    eagerLoadControllersFrom("jet_ui", application)), :yellow
+          return
+        end
+
+        if File.read(path).include?('jet_ui')
+          say "  JetUi controllers already registered in #{JS_CONTROLLERS_FILE}", :yellow
+        else
+          insert_into_file JS_CONTROLLERS_FILE, after: /eagerLoadControllersFrom\("controllers".*\n/ do
+            %(eagerLoadControllersFrom("jet_ui", application)\n)
+          end
+          say "  Registered JetUi controllers in #{JS_CONTROLLERS_FILE}", :green
+        end
+      end
+
       def show_usage
         say "\nJetUi installed!\n", :green
+        say 'Add flash messages to your layout (e.g. app/views/layouts/application.html.erb):'
+        say %(  <%= jet_ui.flash(messages: flash) %>\n)
         say 'Usage in your views:'
         say %(  <%= jet_ui.btn variant: :default do %>Save<% end %>)
         say %(  <%= jet_ui.card do %>)
@@ -61,6 +88,8 @@ module JetUi
         say '  rails generate jet_ui:eject card'
         say "  rails generate jet_ui:eject btn card\n"
       end
+
+      JS_CONTROLLERS_FILE = 'app/javascript/controllers/index.js'
 
       TAILWIND_SOURCE_FILES = %w[
         app/assets/tailwind/application.css

--- a/lib/jet_ui/engine.rb
+++ b/lib/jet_ui/engine.rb
@@ -11,6 +11,17 @@ module JetUi
       end
     end
 
+    initializer 'jet_ui.importmap', after: 'importmap' do |app|
+      if app.respond_to?(:importmap)
+        app.importmap.pin_all_from(
+          root.join('app/assets/javascripts/jet_ui'),
+          under: 'jet_ui'
+        )
+        app.config.importmap.paths << root.join('app/assets/javascripts')
+        app.config.importmap.cache_sweepers << root.join('app/assets/javascripts')
+      end
+    end
+
     initializer 'jet_ui.helpers' do
       require root.join('app/helpers/jet_ui_helper').to_s
       ActiveSupport.on_load(:action_view) do

--- a/test/components/jet_ui/flash/component_test.rb
+++ b/test/components/jet_ui/flash/component_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Flash::ComponentTest < ViewComponent::TestCase
+  def test_renders_turbo_frame
+    render_inline(JetUi::Flash::Component.new(messages: {}))
+
+    assert_selector 'turbo-frame#flash'
+  end
+
+  def test_empty_messages_renders_no_items
+    render_inline(JetUi::Flash::Component.new(messages: {}))
+
+    assert_no_selector 'div.flash-item'
+  end
+
+  def test_renders_notice_message
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Saved!' }))
+
+    assert_selector 'div.flash-item.flash-item-info'
+    assert_text 'Saved!'
+  end
+
+  def test_renders_alert_message
+    render_inline(JetUi::Flash::Component.new(messages: { alert: 'Error!' }))
+
+    assert_selector 'div.flash-item.flash-item-error'
+    assert_text 'Error!'
+  end
+
+  def test_renders_success_message
+    render_inline(JetUi::Flash::Component.new(messages: { success: 'Done!' }))
+
+    assert_selector 'div.flash-item.flash-item-success'
+  end
+
+  def test_renders_warning_message
+    render_inline(JetUi::Flash::Component.new(messages: { warning: 'Watch out!' }))
+
+    assert_selector 'div.flash-item.flash-item-warning'
+  end
+
+  def test_unknown_type_uses_type_as_class
+    render_inline(JetUi::Flash::Component.new(messages: { custom: 'Hello' }))
+
+    assert_selector 'div.flash-item.flash-item-custom'
+  end
+
+  def test_dismissible_renders_close_button
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }))
+
+    assert_selector 'button.flash-item__close'
+  end
+
+  def test_not_dismissible_hides_close_button
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }, dismissible: false))
+
+    assert_no_selector 'button.flash-item__close'
+  end
+
+  def test_dismissible_sets_stimulus_values
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }))
+
+    assert_selector 'div[data-flash-dismiss-after-value]'
+    assert_selector 'div[data-flash-show-delay-value]'
+  end
+
+  def test_not_dismissible_omits_stimulus_values
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }, dismissible: false))
+
+    assert_no_selector 'div[data-flash-dismiss-after-value]'
+  end
+
+  def test_item_has_stimulus_controller
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }))
+
+    assert_selector 'div[data-controller="flash"]'
+  end
+
+  def test_item_starts_hidden
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }))
+
+    assert_selector 'div.flash-item--hidden'
+  end
+
+  def test_blank_messages_are_skipped
+    render_inline(JetUi::Flash::Component.new(messages: { notice: '', alert: 'Real error' }))
+
+    assert_selector 'div.flash-item', count: 1
+  end
+
+  def test_item_id_includes_flash_type
+    render_inline(JetUi::Flash::Component.new(messages: { notice: 'Hi' }))
+
+    assert_selector 'div#flash-notice'
+  end
+end

--- a/test/components/previews/jet_ui/flash/component_preview.rb
+++ b/test/components/previews/jet_ui/flash/component_preview.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class JetUi::Flash::ComponentPreview < ViewComponent::Preview
+  def notice
+    render JetUi::Flash::Component.new(messages: { notice: 'Changes saved successfully.' })
+  end
+
+  def alert
+    render JetUi::Flash::Component.new(messages: { alert: 'Something went wrong. Please try again.' })
+  end
+
+  def success
+    render JetUi::Flash::Component.new(messages: { success: 'Your account has been created.' })
+  end
+
+  def warning
+    render JetUi::Flash::Component.new(messages: { warning: 'Your session will expire soon.' })
+  end
+
+  def multiple
+    render JetUi::Flash::Component.new(
+      messages: {
+        notice: 'Profile updated.',
+        warning: 'Email not verified yet.'
+      }
+    )
+  end
+
+  def non_dismissible
+    render JetUi::Flash::Component.new(
+      messages: { notice: 'This message cannot be dismissed.' },
+      dismissible: false
+    )
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 require 'rails'
 require 'action_controller/railtie'
 require 'action_view/railtie'
+require 'turbo-rails'
 require 'view_component'
 require 'view_component/test_helpers'
 require 'view_component/test_case'


### PR DESCRIPTION
## Summary

Ports the Flash Message component and establishes the infrastructure for distributing and auto-registering Stimulus controllers from the gem.

**Infrastructure changes:**
- Engine initializer auto-pins gem JS via `pin_all_from` so controllers are available in the importmap without any manual configuration
- `jet_ui:install` now configures JS in addition to CSS: adds `eagerLoadControllersFrom("jet_ui", application)` to the Stimulus controllers index — idempotent, safe to re-run after upgrades
- Eject generator extended with `--skip-javascript` flag and `type: :javascript` entries for components that ship a controller

**Flash component:**
- `JetUi::Flash::Component` with turbo_frame, type-mapped CSS classes, `dismissible:` and `frame_id:` options
- `flash_controller.js` — enter/leave animations via CSS transitions + rAF, no `stimulus-use` dependency; `close()` uses `transitionend` with 400ms fallback
- Helper: `jet_ui.flash(messages: flash)`

## Test plan

- [x] `bundle exec rake test` — all tests green
- [x] `bundle exec rubocop` — no offenses
- [x] `rails g jet_ui:install` configures CSS + JS; re-running skips already-configured steps
- [x] Flash messages appear, animate in, auto-dismiss after 5s, close on X click
- [x] `rails g jet_ui:eject flash` copies Ruby, CSS, and JS
- [x] `rails g jet_ui:eject flash --skip-javascript` skips the controller file