### PR TITLE
Port remaining JS-dependent components (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Subcomponents follow the `namespace_subcomponent` naming convention (`card_heade
 | Table | [docs/components/table.md](docs/components/table.md) |
 | Pagy | [docs/components/pagy.md](docs/components/pagy.md) |
 | Flash ⚡ | [docs/components/flash.md](docs/components/flash.md) |
+| Accordion | [docs/components/accordion.md](docs/components/accordion.md) |
+| Clipboard ⚡ | [docs/components/clipboard.md](docs/components/clipboard.md) |
+| Sidebar | [docs/components/sidebar.md](docs/components/sidebar.md) |
+| Header | [docs/components/header.md](docs/components/header.md) |
+| Navbar | [docs/components/navbar.md](docs/components/navbar.md) |
+| Modal ⚡ | [docs/components/modal.md](docs/components/modal.md) |
+| Drawer ⚡ | [docs/components/drawer.md](docs/components/drawer.md) |
+| Dropdown ⚡ | [docs/components/dropdown.md](docs/components/dropdown.md) |
+| Tooltip ⚡ | [docs/components/tooltip.md](docs/components/tooltip.md) |
+| Popover ⚡ | [docs/components/popover.md](docs/components/popover.md) |
+| Turbo Confirm ⚡ | [docs/components/turbo_confirm.md](docs/components/turbo_confirm.md) |
 
 ⚡ Requires Stimulus (configured automatically by `jet_ui:install`).
 

--- a/app/assets/javascripts/jet_ui/clipboard_controller.js
+++ b/app/assets/javascripts/jet_ui/clipboard_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class ClipboardController extends Controller {
+  static values = {
+    content: String,
+    sourceId: String,
+    successText: { type: String, default: "Copied!" },
+    timeout: { type: Number, default: 2000 }
+  }
+
+  connect() {
+    this.originalText = this.#hasTooltip
+      ? this.element.dataset.tooltipContentValue
+      : this.element.textContent
+  }
+
+  async copy() {
+    const text = this.#getContent()
+    await navigator.clipboard.writeText(text)
+
+    if (!this.#hasTooltip) {
+      this.element.textContent = this.successTextValue
+    }
+
+    this.dispatch("change", { detail: { content: this.successTextValue } })
+
+    setTimeout(() => {
+      if (!this.#hasTooltip) {
+        this.element.textContent = this.originalText
+      }
+      this.dispatch("change", { detail: { content: this.originalText } })
+    }, this.timeoutValue)
+  }
+
+  get #hasTooltip() {
+    return this.element.dataset.controller?.includes("tooltip")
+  }
+
+  #getContent() {
+    if (this.hasSourceIdValue) {
+      const el = document.getElementById(this.sourceIdValue)
+      return el?.value ?? el?.textContent ?? ""
+    }
+    return this.contentValue
+  }
+}

--- a/app/assets/javascripts/jet_ui/drawer_controller.js
+++ b/app/assets/javascripts/jet_ui/drawer_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class DrawerController extends Controller {
+  static values = {
+    swipeThreshold: { type: Number, default: 100 }
+  }
+
+  connect() {
+    this.element.addEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this.element.addEventListener("touchstart", this.#onTouchStart.bind(this), { passive: true })
+    this.element.addEventListener("touchmove", this.#onTouchMove.bind(this), { passive: true })
+    this.element.addEventListener("touchend", this.#onTouchEnd.bind(this), { passive: true })
+    this.element.showModal()
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this.element.removeEventListener("touchstart", this.#onTouchStart.bind(this))
+    this.element.removeEventListener("touchmove", this.#onTouchMove.bind(this))
+    this.element.removeEventListener("touchend", this.#onTouchEnd.bind(this))
+    this.close()
+  }
+
+  show() {
+    this.element.showModal()
+  }
+
+  close() {
+    try {
+      this.element.close()
+      DrawerController.turboFrame.src = null
+      this.element.remove()
+    } catch (e) {}
+  }
+
+  #closeOnBackdropClick(event) {
+    if (event.target === this.element) {
+      this.close()
+    }
+  }
+
+  #onTouchStart(event) {
+    this.touchStartX = event.touches[0].clientX
+    this.element.style.transition = "none"
+  }
+
+  #onTouchMove(event) {
+    const currentX = event.touches[0].clientX
+    const diff = Math.max(0, currentX - this.touchStartX)
+    this.element.style.transform = `translateX(${diff}px)`
+  }
+
+  #onTouchEnd(event) {
+    const touchEndX = event.changedTouches[0].clientX
+    const diff = touchEndX - this.touchStartX
+
+    this.element.style.transition = "transform 0.2s ease-out"
+
+    if (diff > this.swipeThresholdValue) {
+      this.element.style.transform = "translateX(100%)"
+      this.element.addEventListener("transitionend", () => this.close(), { once: true })
+    } else {
+      this.element.style.transform = "translateX(0)"
+    }
+  }
+
+  static get turboFrame() {
+    return document.querySelector("turbo-frame[id='drawer']")
+  }
+}

--- a/app/assets/javascripts/jet_ui/drawers_controller.js
+++ b/app/assets/javascripts/jet_ui/drawers_controller.js
@@ -10,7 +10,7 @@ export default class DrawersController extends Controller {
     this.#removeDialogListeners()
   }
 
-  show(e) {
+  open(e) {
     this.openedDialog = this.#getDialog(e)
     this.#addDialogListeners()
     this.openedDialog?.showModal()

--- a/app/assets/javascripts/jet_ui/drawers_controller.js
+++ b/app/assets/javascripts/jet_ui/drawers_controller.js
@@ -1,0 +1,83 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class DrawersController extends Controller {
+  static targets = ["dialog"]
+  static values = {
+    swipeThreshold: { type: Number, default: 100 }
+  }
+
+  disconnect() {
+    this.#removeDialogListeners()
+  }
+
+  show(e) {
+    this.openedDialog = this.#getDialog(e)
+    this.#addDialogListeners()
+    this.openedDialog?.showModal()
+  }
+
+  close(e) {
+    this.#removeDialogListeners()
+    this.#getDialog(e)?.close()
+  }
+
+  #getDialog(e) {
+    const id = e.currentTarget.dataset.id
+    return this.dialogTargets.find(dialog => dialog.id === id)
+  }
+
+  #addDialogListeners() {
+    if (!this.openedDialog) return
+    this._backdropClick = this.#closeOnBackdropClick.bind(this)
+    this._touchStart = this.#onTouchStart.bind(this)
+    this._touchMove = this.#onTouchMove.bind(this)
+    this._touchEnd = this.#onTouchEnd.bind(this)
+    this.openedDialog.addEventListener("click", this._backdropClick)
+    this.openedDialog.addEventListener("touchstart", this._touchStart, { passive: true })
+    this.openedDialog.addEventListener("touchmove", this._touchMove, { passive: true })
+    this.openedDialog.addEventListener("touchend", this._touchEnd, { passive: true })
+  }
+
+  #removeDialogListeners() {
+    if (!this.openedDialog || !this._backdropClick) return
+    this.openedDialog.removeEventListener("click", this._backdropClick)
+    this.openedDialog.removeEventListener("touchstart", this._touchStart)
+    this.openedDialog.removeEventListener("touchmove", this._touchMove)
+    this.openedDialog.removeEventListener("touchend", this._touchEnd)
+  }
+
+  #closeOnBackdropClick(e) {
+    if (e.target === this.openedDialog) {
+      this.openedDialog.close()
+    }
+  }
+
+  #onTouchStart(event) {
+    this.touchStartX = event.touches[0].clientX
+    this.openedDialog.style.transition = "none"
+  }
+
+  #onTouchMove(event) {
+    const currentX = event.touches[0].clientX
+    const diff = Math.max(0, currentX - this.touchStartX)
+    this.openedDialog.style.transform = `translateX(${diff}px)`
+  }
+
+  #onTouchEnd(event) {
+    const touchEndX = event.changedTouches[0].clientX
+    const diff = touchEndX - this.touchStartX
+
+    this.openedDialog.style.transition = "transform 0.2s ease-out"
+
+    if (diff > this.swipeThresholdValue) {
+      this.openedDialog.style.transform = "translateX(100%)"
+      this.openedDialog.addEventListener("transitionend", () => {
+        this.openedDialog.close()
+        this.openedDialog.style.transform = ""
+        this.openedDialog.style.transition = ""
+      }, { once: true })
+    } else {
+      this.openedDialog.style.transform = "translateX(0)"
+    }
+  }
+}

--- a/app/assets/javascripts/jet_ui/dropdown_controller.js
+++ b/app/assets/javascripts/jet_ui/dropdown_controller.js
@@ -1,0 +1,95 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class DropdownController extends Controller {
+  static targets = ["menu", "autofocus"]
+  static values = { open: { type: Boolean, default: false } }
+
+  connect() {
+    this._handleClick = this.#handleClick.bind(this)
+    this._clickOutside = this.#clickOutside.bind(this)
+    this._handleKeydown = this.#handleKeydown.bind(this)
+    this._handleMorph = this.#handleMorph.bind(this)
+    this.element.addEventListener("click", this._handleClick)
+    document.addEventListener("turbo:morph", this._handleMorph)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this._handleClick)
+    document.removeEventListener("click", this._clickOutside)
+    document.removeEventListener("keydown", this._handleKeydown)
+    document.removeEventListener("turbo:morph", this._handleMorph)
+  }
+
+  toggle() { this.openValue = !this.openValue }
+  show()   { this.openValue = true }
+  hide()   { this.openValue = false }
+
+  openValueChanged(isOpen) {
+    isOpen ? this.#showMenu() : this.#hideMenu()
+  }
+
+  #handleClick(event) {
+    if (!this.menuTarget.contains(event.target)) {
+      this.toggle()
+    }
+  }
+
+  #showMenu() {
+    this.menuTarget.classList.remove("hidden")
+    this.menuTarget.classList.add("block")
+    this.#updatePosition()
+    if (this.hasAutofocusTarget) this.autofocusTarget.focus()
+    document.addEventListener("click", this._clickOutside)
+    document.addEventListener("keydown", this._handleKeydown)
+  }
+
+  #hideMenu() {
+    this.menuTarget.classList.remove("block")
+    this.menuTarget.classList.add("hidden")
+    document.removeEventListener("click", this._clickOutside)
+    document.removeEventListener("keydown", this._handleKeydown)
+  }
+
+  #handleKeydown(event) {
+    if (event.key === "Escape") this.hide()
+  }
+
+  #clickOutside(event) {
+    if (!this.element.contains(event.target)) this.hide()
+  }
+
+  #handleMorph() {
+    if (this.openValue) this.#showMenu()
+  }
+
+  #updatePosition() {
+    const ref = this.element
+    const floating = this.menuTarget
+    const refRect = ref.getBoundingClientRect()
+    const floatRect = floating.getBoundingClientRect()
+    const viewport = { w: window.innerWidth, h: window.innerHeight }
+    const gap = 5
+
+    // Coordinates relative to the .dropdown parent (position: relative)
+    let x = 0
+    let y = ref.offsetHeight + gap
+
+    // Flip up if overflows bottom viewport
+    if (refRect.bottom + gap + floatRect.height > viewport.h) {
+      y = -(floatRect.height + gap)
+    }
+
+    // Shift left if overflows right edge
+    if (refRect.left + floatRect.width > viewport.w - 8) {
+      x = ref.offsetWidth - floatRect.width
+    }
+
+    // Clamp so menu doesn't overflow left edge of viewport
+    x = Math.max(-refRect.left + 8, x)
+
+    Object.assign(floating.style, {
+      left: `${x}px`,
+      top: `${y}px`
+    })
+  }
+}

--- a/app/assets/javascripts/jet_ui/modal_controller.js
+++ b/app/assets/javascripts/jet_ui/modal_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class ModalController extends Controller {
+  connect() {
+    this.element.addEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this.element.showModal()
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this.close()
+  }
+
+  show() {
+    this.element.showModal()
+  }
+
+  close() {
+    try {
+      this.element.close()
+      ModalController.turboFrame.src = null
+      this.element.remove()
+    } catch (e) {}
+  }
+
+  #closeOnBackdropClick(event) {
+    if (event.target === this.element) {
+      this.close()
+    }
+  }
+
+  static get turboFrame() {
+    return document.querySelector("turbo-frame[id='modal']")
+  }
+}

--- a/app/assets/javascripts/jet_ui/modals_controller.js
+++ b/app/assets/javascripts/jet_ui/modals_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class ModalsController extends Controller {
+  static targets = ["dialog"]
+
+  disconnect() {
+    this.openedDialog?.removeEventListener("click", this.#closeOnBackdropClick.bind(this))
+  }
+
+  show(e) {
+    this.openedDialog = this.#getDialog(e)
+    this.openedDialog?.addEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this.openedDialog?.showModal()
+  }
+
+  close(e) {
+    this.#getDialog(e)?.close()
+  }
+
+  #getDialog(e) {
+    const id = e.currentTarget.dataset.id
+    return this.dialogTargets.find(dialog => dialog.id === id)
+  }
+
+  #closeOnBackdropClick(e) {
+    if (e.target === this.openedDialog) {
+      this.openedDialog.close()
+    }
+  }
+}

--- a/app/assets/javascripts/jet_ui/modals_controller.js
+++ b/app/assets/javascripts/jet_ui/modals_controller.js
@@ -7,7 +7,7 @@ export default class ModalsController extends Controller {
     this.openedDialog?.removeEventListener("click", this.#closeOnBackdropClick.bind(this))
   }
 
-  show(e) {
+  open(e) {
     this.openedDialog = this.#getDialog(e)
     this.openedDialog?.addEventListener("click", this.#closeOnBackdropClick.bind(this))
     this.openedDialog?.showModal()

--- a/app/assets/javascripts/jet_ui/popover_controller.js
+++ b/app/assets/javascripts/jet_ui/popover_controller.js
@@ -1,0 +1,97 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class PopoverController extends Controller {
+  static targets = ["content"]
+  static values = {
+    open: { type: Boolean, default: false },
+    placement: { type: String, default: "bottom" }
+  }
+
+  connect() {
+    this._mouseEnter = () => { this.openValue = true }
+    this._mouseLeave = () => { this.openValue = false }
+    this._handleMorph = this.#handleMorph.bind(this)
+    this.element.addEventListener("mouseenter", this._mouseEnter)
+    this.element.addEventListener("mouseleave", this._mouseLeave)
+    document.addEventListener("turbo:morph", this._handleMorph)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("mouseenter", this._mouseEnter)
+    this.element.removeEventListener("mouseleave", this._mouseLeave)
+    document.removeEventListener("turbo:morph", this._handleMorph)
+  }
+
+  openValueChanged(isOpen) {
+    isOpen ? this.#showContent() : this.#hideContent()
+  }
+
+  #showContent() {
+    this.contentTarget.classList.remove("opacity-0", "pointer-events-none")
+    this.contentTarget.classList.add("opacity-100", "pointer-events-auto")
+    this.#updatePosition()
+  }
+
+  #hideContent() {
+    this.contentTarget.classList.remove("opacity-100", "pointer-events-auto")
+    this.contentTarget.classList.add("opacity-0", "pointer-events-none")
+  }
+
+  #handleMorph() {
+    if (this.openValue) this.#showContent()
+  }
+
+  #updatePosition() {
+    const ref = this.element
+    const floating = this.contentTarget
+    const refRect = ref.getBoundingClientRect()
+    const floatRect = floating.getBoundingClientRect()
+    const viewport = { w: window.innerWidth, h: window.innerHeight }
+    const gap = 12
+    const placement = this.placementValue
+
+    let x, y, effectivePlacement = placement
+
+    switch (placement) {
+      case "bottom":
+        x = (refRect.width - floatRect.width) / 2
+        y = refRect.height + gap
+        if (refRect.bottom + gap + floatRect.height > viewport.h) {
+          y = -(floatRect.height + gap); effectivePlacement = "top"
+        }
+        break
+      case "top":
+        x = (refRect.width - floatRect.width) / 2
+        y = -(floatRect.height + gap)
+        if (refRect.top - gap - floatRect.height < 0) {
+          y = refRect.height + gap; effectivePlacement = "bottom"
+        }
+        break
+      case "right":
+        x = refRect.width + gap
+        y = (refRect.height - floatRect.height) / 2
+        if (refRect.right + gap + floatRect.width > viewport.w) {
+          x = -(floatRect.width + gap); effectivePlacement = "left"
+        }
+        break
+      case "left":
+        x = -(floatRect.width + gap)
+        y = (refRect.height - floatRect.height) / 2
+        if (refRect.left - gap - floatRect.width < 0) {
+          x = refRect.width + gap; effectivePlacement = "right"
+        }
+        break
+      default:
+        x = (refRect.width - floatRect.width) / 2
+        y = refRect.height + gap
+    }
+
+    // Shift horizontally to stay in viewport
+    const absoluteX = refRect.left + x
+    if (absoluteX < 8) x += (8 - absoluteX)
+    if (absoluteX + floatRect.width > viewport.w - 8) x -= (absoluteX + floatRect.width - viewport.w + 8)
+
+    Object.assign(floating.style, { left: `${x}px`, top: `${y}px` })
+    floating.dataset.placement = effectivePlacement
+  }
+}

--- a/app/assets/javascripts/jet_ui/popover_controller.js
+++ b/app/assets/javascripts/jet_ui/popover_controller.js
@@ -27,14 +27,12 @@ export default class PopoverController extends Controller {
   }
 
   #showContent() {
-    this.contentTarget.classList.remove("opacity-0", "pointer-events-none")
-    this.contentTarget.classList.add("opacity-100", "pointer-events-auto")
+    this.contentTarget.classList.add("popover--visible")
     this.#updatePosition()
   }
 
   #hideContent() {
-    this.contentTarget.classList.remove("opacity-100", "pointer-events-auto")
-    this.contentTarget.classList.add("opacity-0", "pointer-events-none")
+    this.contentTarget.classList.remove("popover--visible")
   }
 
   #handleMorph() {

--- a/app/assets/javascripts/jet_ui/tooltip_controller.js
+++ b/app/assets/javascripts/jet_ui/tooltip_controller.js
@@ -1,0 +1,107 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class TooltipController extends Controller {
+  static values = {
+    content: String,
+    placement: { type: String, default: "top" }
+  }
+
+  connect() {
+    this._mouseEnter = this.#mouseEnter.bind(this)
+    this._mouseLeave = this.#mouseLeave.bind(this)
+    this.element.addEventListener("mouseenter", this._mouseEnter)
+    this.element.addEventListener("mouseleave", this._mouseLeave)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("mouseenter", this._mouseEnter)
+    this.element.removeEventListener("mouseleave", this._mouseLeave)
+    this.tooltip?.remove()
+    this.tooltip = null
+  }
+
+  updateContent(event) {
+    const text = event.detail?.content
+    if (text) this.contentValue = text
+  }
+
+  contentValueChanged(value) {
+    if (this.tooltip) {
+      this.tooltip.innerHTML = value
+      this.#updatePosition()
+    }
+  }
+
+  #mouseEnter() {
+    this.#createTooltip()
+    this.#updatePosition()
+  }
+
+  #mouseLeave() {
+    this.tooltip?.remove()
+    this.tooltip = null
+  }
+
+  #createTooltip() {
+    this.tooltip = document.createElement("div")
+    this.tooltip.className = "tooltip"
+    this.tooltip.role = "tooltip"
+    this.tooltip.innerHTML = this.contentValue
+    const container = this.element.closest("dialog") || document.body
+    container.appendChild(this.tooltip)
+  }
+
+  #updatePosition() {
+    if (!this.tooltip) return
+
+    // Measure tooltip dimensions
+    this.tooltip.style.visibility = "hidden"
+    this.tooltip.style.position = "fixed"
+    this.tooltip.style.left = "-9999px"
+    const floatRect = this.tooltip.getBoundingClientRect()
+    this.tooltip.style.visibility = ""
+    this.tooltip.style.position = ""
+    this.tooltip.style.left = ""
+
+    const ref = this.element
+    const refRect = ref.getBoundingClientRect()
+    const viewport = { w: window.innerWidth, h: window.innerHeight }
+    const gap = 8
+    const placement = this.placementValue
+
+    let x, y, effectivePlacement = placement
+
+    switch (placement) {
+      case "top":
+        x = refRect.left + (refRect.width - floatRect.width) / 2
+        y = refRect.top - floatRect.height - gap
+        if (y < 0) { y = refRect.bottom + gap; effectivePlacement = "bottom" }
+        break
+      case "bottom":
+        x = refRect.left + (refRect.width - floatRect.width) / 2
+        y = refRect.bottom + gap
+        if (y + floatRect.height > viewport.h) { y = refRect.top - floatRect.height - gap; effectivePlacement = "top" }
+        break
+      case "left":
+        x = refRect.left - floatRect.width - gap
+        y = refRect.top + (refRect.height - floatRect.height) / 2
+        if (x < 0) { x = refRect.right + gap; effectivePlacement = "right" }
+        break
+      case "right":
+        x = refRect.right + gap
+        y = refRect.top + (refRect.height - floatRect.height) / 2
+        if (x + floatRect.width > viewport.w) { x = refRect.left - floatRect.width - gap; effectivePlacement = "left" }
+        break
+      default:
+        x = refRect.left + (refRect.width - floatRect.width) / 2
+        y = refRect.top - floatRect.height - gap
+    }
+
+    // Shift to keep within viewport
+    x = Math.max(8, Math.min(x + window.scrollX, viewport.w + window.scrollX - floatRect.width - 8))
+    y = Math.max(8, Math.min(y + window.scrollY, viewport.h + window.scrollY - floatRect.height - 8))
+
+    Object.assign(this.tooltip.style, { left: `${x}px`, top: `${y}px` })
+    this.tooltip.dataset.placement = effectivePlacement
+  }
+}

--- a/app/assets/javascripts/jet_ui/turbo_confirm_controller.js
+++ b/app/assets/javascripts/jet_ui/turbo_confirm_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class TurboConfirmController extends Controller {
+  connect() {
+    window.Turbo.config.forms.confirm = (message) => {
+      const dialog = this.element
+      const messageEl = dialog.querySelector("p")
+      if (messageEl) messageEl.textContent = message
+      dialog.showModal()
+
+      return new Promise((resolve) => {
+        dialog.addEventListener("close", () => {
+          resolve(dialog.returnValue === "confirm")
+        }, { once: true })
+
+        dialog.addEventListener("click", (event) => {
+          if (event.target === dialog) {
+            dialog.returnValue = "cancel"
+            dialog.close()
+          }
+        })
+      })
+    }
+  }
+}

--- a/app/assets/stylesheets/jet_ui.css
+++ b/app/assets/stylesheets/jet_ui.css
@@ -17,3 +17,11 @@
 @import "./jet_ui/table.css";
 @import "./jet_ui/pagy.css";
 @import "./jet_ui/flash.css";
+@import "./jet_ui/sidebar.css";
+@import "./jet_ui/header.css";
+@import "./jet_ui/navbar.css";
+@import "./jet_ui/modal.css";
+@import "./jet_ui/drawer.css";
+@import "./jet_ui/dropdown.css";
+@import "./jet_ui/tooltip.css";
+@import "./jet_ui/popover.css";

--- a/app/assets/stylesheets/jet_ui/drawer.css
+++ b/app/assets/stylesheets/jet_ui/drawer.css
@@ -1,0 +1,46 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .drawer {
+    @apply fixed inset-0 left-auto flex-col hidden m-0 min-h-full shadow-sm w-2xl;
+    @apply bg-card backdrop:bg-overlay rounded-tl-modal rounded-bl-modal;
+  }
+
+  .drawer[open] {
+    @apply flex;
+  }
+
+  .drawer__header {
+    @apply sticky top-0 flex items-center justify-between p-4 px-6 backdrop-blur-sm bg-card/70;
+  }
+
+  .drawer__header-bordered {
+    @apply border-b border-border;
+  }
+
+  .drawer__title {
+    @apply text-xl font-semibold leading-tight text-foreground;
+  }
+
+  .drawer__subtitle {
+    @apply mt-1 text-sm text-muted-foreground;
+  }
+
+  .drawer__close {
+    @apply inline-flex items-center p-1 ml-auto text-sm transition-all duration-300 bg-transparent rounded-full cursor-pointer outline-0;
+    @apply text-muted-foreground hover:bg-accent hover:text-accent-foreground;
+  }
+
+  .drawer__body {
+    @apply flex-1 p-6 text-muted-foreground;
+  }
+
+  .drawer__footer {
+    @apply sticky bottom-0 w-full p-4 backdrop-blur-sm bg-card/70;
+    border-bottom-left-radius: var(--radius-modal);
+  }
+
+  .drawer__footer-bordered {
+    @apply border-t border-border;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/dropdown.css
+++ b/app/assets/stylesheets/jet_ui/dropdown.css
@@ -1,0 +1,33 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .dropdown {
+    @apply relative w-fit;
+  }
+
+  .dropdown__menu {
+    @apply absolute z-40 hidden overflow-auto py-1.5 shadow min-w-44 animate-fade-in max-w-96 max-h-96;
+    @apply bg-popover border border-border text-foreground rounded-dropdown;
+  }
+
+  .dropdown__title {
+    @apply px-4 py-1 font-semibold text-sm text-foreground;
+  }
+
+  .dropdown__item {
+    @apply block mx-2;
+  }
+
+  .dropdown__link {
+    @apply block w-full px-2 py-1.5 text-sm text-left cursor-pointer rounded-btn-md;
+    @apply hover:bg-accent hover:text-accent-foreground;
+  }
+
+  .dropdown__link-active {
+    @apply bg-accent text-accent-foreground;
+  }
+
+  .dropdown__divider {
+    @apply pb-2 mb-2 border-b border-border;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/header.css
+++ b/app/assets/stylesheets/jet_ui/header.css
@@ -37,29 +37,29 @@
   .header__actions {
     @apply flex items-center shrink-0 gap-2 whitespace-nowrap;
   }
+}
 
-  @media (min-width: 768px) {
-    .header {
-      padding-block: calc(var(--spacing) * 6);
-    }
-
-    .header--row {
-      flex-direction: row;
-    }
+@media (min-width: 768px) {
+  .header {
+    padding-block: calc(var(--spacing) * 6);
   }
 
-  @media (min-width: 1024px) {
-    .header {
-      column-gap: calc(var(--spacing) * 16);
-    }
+  .header--row {
+    flex-direction: row;
+  }
+}
 
-    .header--sticky {
-      position: sticky;
-      z-index: 30;
-      top: var(--height-navbar);
-      background-color: color-mix(in oklab, var(--color-muted) 90%, transparent);
-      -webkit-backdrop-filter: blur(var(--blur-xs));
-      backdrop-filter: blur(var(--blur-xs));
-    }
+@media (min-width: 1024px) {
+  .header {
+    column-gap: calc(var(--spacing) * 16);
+  }
+
+  .header--sticky {
+    position: sticky;
+    z-index: 30;
+    top: var(--height-navbar);
+    background-color: color-mix(in oklab, var(--color-muted) 90%, transparent);
+    -webkit-backdrop-filter: blur(var(--blur-xs));
+    backdrop-filter: blur(var(--blur-xs));
   }
 }

--- a/app/assets/stylesheets/jet_ui/header.css
+++ b/app/assets/stylesheets/jet_ui/header.css
@@ -1,0 +1,65 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .header {
+    @apply flex gap-y-2 py-3;
+    column-gap: calc(var(--spacing) * 8);
+  }
+
+  .header--row { flex-direction: column; }
+  .header--col { flex-direction: column; }
+
+  .header--align-start   { @apply items-start; }
+  .header--align-center  { @apply items-center; }
+  .header--align-end     { @apply items-end; }
+
+  .header--justify-start   { @apply justify-start; }
+  .header--justify-center  { @apply justify-center; }
+  .header--justify-end     { @apply justify-end; }
+  .header--justify-between { @apply justify-between; }
+
+  .header--bordered {
+    @apply pb-4 border-b border-border;
+  }
+
+  .header__heading {
+    @apply flex-1 flex flex-col gap-2;
+  }
+
+  .header__title {
+    @apply flex items-center gap-2 flex-1 font-semibold tracking-tight text-3xl;
+  }
+
+  .header__subtitle {
+    @apply text-base text-muted-foreground;
+  }
+
+  .header__actions {
+    @apply flex items-center shrink-0 gap-2 whitespace-nowrap;
+  }
+
+  @media (min-width: 768px) {
+    .header {
+      padding-block: calc(var(--spacing) * 6);
+    }
+
+    .header--row {
+      flex-direction: row;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .header {
+      column-gap: calc(var(--spacing) * 16);
+    }
+
+    .header--sticky {
+      position: sticky;
+      z-index: 30;
+      top: var(--height-navbar);
+      background-color: color-mix(in oklab, var(--color-muted) 90%, transparent);
+      -webkit-backdrop-filter: blur(var(--blur-xs));
+      backdrop-filter: blur(var(--blur-xs));
+    }
+  }
+}

--- a/app/assets/stylesheets/jet_ui/modal.css
+++ b/app/assets/stylesheets/jet_ui/modal.css
@@ -1,0 +1,47 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .modal {
+    @apply p-0 m-auto shadow-sm max-w-11/12 h-fit w-2xl;
+    @apply bg-card rounded-modal backdrop:bg-overlay;
+  }
+
+  .modal-page {
+    @apply mt-4;
+  }
+
+  .modal__header {
+    @apply sticky top-0 flex items-start justify-between p-4 px-6 backdrop-blur-sm bg-card/70;
+  }
+
+  .modal__header-bordered {
+    @apply border-b border-border;
+  }
+
+  .modal__title {
+    @apply text-xl font-semibold leading-tight text-foreground;
+  }
+
+  .modal__subtitle {
+    @apply mt-1 text-sm text-muted-foreground;
+  }
+
+  .modal__close {
+    @apply inline-flex items-center p-1 ml-auto text-sm transition-all duration-300 bg-transparent rounded-full cursor-pointer outline-0;
+    @apply text-muted-foreground hover:bg-accent hover:text-accent-foreground;
+  }
+
+  .modal__body {
+    @apply px-6 py-6 overflow-auto rounded-modal;
+  }
+
+  .modal__footer {
+    @apply sticky bottom-0 w-full p-4 backdrop-blur-sm bg-card/70;
+    border-bottom-left-radius: var(--radius-modal);
+    border-bottom-right-radius: var(--radius-modal);
+  }
+
+  .modal__footer-bordered {
+    @apply border-t border-border;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/navbar.css
+++ b/app/assets/stylesheets/jet_ui/navbar.css
@@ -15,16 +15,16 @@
     @apply flex items-center gap-3;
   }
 
-  .navbar__content {
+  .navbar__main {
     @apply flex flex-1 items-center justify-between;
   }
 
-  .navbar__actions {
-    @apply flex items-center gap-2 ml-auto;
+  .navbar__content {
+    @apply flex items-center gap-4;
   }
 
-  .navbar__main {
-    @apply flex items-center justify-between;
+  .navbar__actions {
+    @apply flex items-center gap-2;
   }
 }
 

--- a/app/assets/stylesheets/jet_ui/navbar.css
+++ b/app/assets/stylesheets/jet_ui/navbar.css
@@ -7,13 +7,6 @@
     height: var(--height-navbar);
   }
 
-  @media (min-width: 768px) {
-    .navbar {
-      display: grid;
-      grid-template-columns: var(--width-sidebar) 1fr;
-    }
-  }
-
   .navbar-sticky {
     @apply sticky top-0;
   }
@@ -23,7 +16,7 @@
   }
 
   .navbar__content {
-    @apply flex-1;
+    @apply flex flex-1 items-center justify-between;
   }
 
   .navbar__actions {
@@ -32,5 +25,12 @@
 
   .navbar__main {
     @apply flex items-center justify-between;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar {
+    display: grid;
+    grid-template-columns: var(--width-sidebar) 1fr;
   }
 }

--- a/app/assets/stylesheets/jet_ui/navbar.css
+++ b/app/assets/stylesheets/jet_ui/navbar.css
@@ -1,0 +1,36 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .navbar {
+    @apply z-20 w-full backdrop-blur-xs bg-background/90;
+    @apply flex items-center justify-between gap-6;
+    height: var(--height-navbar);
+  }
+
+  @media (min-width: 768px) {
+    .navbar {
+      display: grid;
+      grid-template-columns: var(--width-sidebar) 1fr;
+    }
+  }
+
+  .navbar-sticky {
+    @apply sticky top-0;
+  }
+
+  .navbar__brand {
+    @apply flex items-center gap-3;
+  }
+
+  .navbar__content {
+    @apply flex-1;
+  }
+
+  .navbar__actions {
+    @apply flex items-center gap-2 ml-auto;
+  }
+
+  .navbar__main {
+    @apply flex items-center justify-between;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/popover.css
+++ b/app/assets/stylesheets/jet_ui/popover.css
@@ -1,6 +1,11 @@
 @layer theme, base, components, utilities;
 
 @layer components {
+  [data-controller~="popover"] {
+    position: relative;
+    width: fit-content;
+  }
+
   .popover {
     @apply absolute z-10 w-64 text-sm shadow-sm;
     @apply text-muted-foreground bg-popover border border-border rounded-dropdown;

--- a/app/assets/stylesheets/jet_ui/popover.css
+++ b/app/assets/stylesheets/jet_ui/popover.css
@@ -2,8 +2,16 @@
 
 @layer components {
   .popover {
-    @apply absolute z-10 w-64 text-sm transition-opacity duration-300 shadow-sm opacity-0 pointer-events-none;
+    @apply absolute z-10 w-64 text-sm shadow-sm;
     @apply text-muted-foreground bg-popover border border-border rounded-dropdown;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+  }
+
+  .popover--visible {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .popover::after {

--- a/app/assets/stylesheets/jet_ui/popover.css
+++ b/app/assets/stylesheets/jet_ui/popover.css
@@ -1,0 +1,38 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .popover {
+    @apply absolute z-10 w-64 text-sm transition-opacity duration-300 shadow-sm opacity-0 pointer-events-none;
+    @apply text-muted-foreground bg-popover border border-border rounded-dropdown;
+  }
+
+  .popover::after {
+    @apply absolute rotate-45 size-2.5 bg-popover border border-border;
+    content: "";
+  }
+
+  .popover[data-placement^="top"]::after {
+    @apply bottom-0 -translate-x-1/2 translate-y-1/2 border-t-0 border-l-0 left-1/2;
+  }
+
+  .popover[data-placement^="bottom"]::after {
+    @apply top-0 -translate-x-1/2 -translate-y-1/2 border-b-0 border-r-0 left-1/2 bg-muted;
+  }
+
+  .popover[data-placement^="left"]::after {
+    @apply right-0 translate-x-1/2 -translate-y-1/2 border-b-0 border-l-0 top-1/2;
+  }
+
+  .popover[data-placement^="right"]::after {
+    @apply left-0 -translate-x-1/2 -translate-y-1/2 border-t-0 border-r-0 top-1/2;
+  }
+
+  .popover__title {
+    @apply px-3 py-3 font-semibold text-foreground bg-muted border-b border-border;
+    @apply rounded-tl-dropdown rounded-tr-dropdown;
+  }
+
+  .popover__body {
+    @apply p-3;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/sidebar.css
+++ b/app/assets/stylesheets/jet_ui/sidebar.css
@@ -1,0 +1,35 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .sidebar {
+    @apply flex flex-col gap-y-8 overflow-y-auto text-sm;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+  }
+
+  .sidebar__section {
+    @apply flex flex-col gap-3;
+  }
+
+  .sidebar__title {
+    @apply flex items-center justify-between gap-2 font-semibold text-foreground;
+  }
+
+  .sidebar__menu {
+    @apply flex flex-col gap-1;
+  }
+
+  .sidebar__link {
+    @apply block px-3 py-1.5 font-medium text-muted-foreground rounded-btn-md;
+    @apply hover:text-foreground;
+  }
+
+  .sidebar__link-active {
+    @apply font-semibold bg-muted text-foreground;
+  }
+
+  .sidebar__link-disabled {
+    @apply cursor-not-allowed font-normal text-muted-foreground;
+    @apply hover:text-muted-foreground;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/theme.css
+++ b/app/assets/stylesheets/jet_ui/theme.css
@@ -1,3 +1,20 @@
+@layer base {
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  @keyframes slideUp {
+    from { opacity: 0.7; transform: translateY(2rem); }
+    to   { opacity: 1;   transform: translateY(0); }
+  }
+
+  @keyframes slideLeft {
+    from { opacity: 0.8; transform: translateX(3rem); }
+    to   { opacity: 1;   transform: translateX(0); }
+  }
+}
+
 :root {
   --accent-hue: 262;
   --accent-chroma: 0.245;
@@ -6,6 +23,17 @@
 }
 
 @theme {
+  /* Layout */
+  --height-navbar: 54px;
+  --width-sidebar: 220px;
+  --spacing-navbar: var(--height-navbar);
+  --spacing-sidebar: var(--width-sidebar);
+
+  /* Animations */
+  --animate-fade-in: fadeIn 0.15s ease-in-out;
+  --animate-slide-up: slideUp 0.3s ease-in-out;
+  --animate-slide-left: slideLeft 0.3s ease-in-out;
+
   /* Radius */
   --radius-btn-xs: calc(var(--radius-md) * 0.75);
   --radius-btn-sm: calc(var(--radius-md) * 1);
@@ -29,6 +57,12 @@
   --color-gray-800: oklch(0.278 var(--gray-chroma) var(--accent-hue));
   --color-gray-900: oklch(0.21  var(--gray-chroma) var(--accent-hue));
   --color-gray-950: oklch(0.13  var(--gray-chroma) var(--accent-hue));
+
+  /* Card / Popover (semantic surface tokens) */
+  --color-card:             var(--color-surface);
+  --color-card-foreground:  var(--color-surface-foreground);
+  --color-popover:          var(--color-surface);
+  --color-popover-foreground: var(--color-surface-foreground);
 
   /* Layout */
   --color-background:         var(--color-gray-50);

--- a/app/assets/stylesheets/jet_ui/tooltip.css
+++ b/app/assets/stylesheets/jet_ui/tooltip.css
@@ -1,0 +1,33 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  .tooltip {
+    --tooltip-bg: var(--color-gray-900);
+
+    @apply absolute z-20 px-3 py-2 text-xs text-center shadow-sm pointer-events-none;
+    @apply text-white rounded-tooltip;
+    background-color: var(--tooltip-bg);
+  }
+
+  .tooltip::after {
+    @apply absolute rotate-45 size-2;
+    background-color: var(--tooltip-bg);
+    content: "";
+  }
+
+  .tooltip[data-placement^="top"]::after {
+    @apply bottom-0 -translate-x-1/2 translate-y-1/2 left-1/2;
+  }
+
+  .tooltip[data-placement^="bottom"]::after {
+    @apply top-0 -translate-x-1/2 -translate-y-1/2 left-1/2;
+  }
+
+  .tooltip[data-placement^="left"]::after {
+    @apply right-0 translate-x-1/2 -translate-y-1/2 top-1/2;
+  }
+
+  .tooltip[data-placement^="right"]::after {
+    @apply left-0 -translate-x-1/2 -translate-y-1/2 top-1/2;
+  }
+}

--- a/app/components/jet_ui/accordion/body_component.rb
+++ b/app/components/jet_ui/accordion/body_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Accordion
+    class BodyComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('pb-3.5', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/accordion/component.rb
+++ b/app/components/jet_ui/accordion/component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Accordion
+    class Component < JetUi::BaseComponent
+      def initialize(name: nil, open: false, **options)
+        @name = name
+        @open = open
+        @options = options
+      end
+
+      def call
+        content_tag :details, content, class: classes, name: @name, open: @open,
+                                       **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('group', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/accordion/summary_component.rb
+++ b/app/components/jet_ui/accordion/summary_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Accordion
+    class SummaryComponent < JetUi::BaseComponent
+      def initialize(icon: 'chevron-down', **options)
+        @icon = icon
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <summary class="<%= classes %>">
+          <%= content %>
+          <%= helpers.jet_ui.icon(@icon, class: icon_classes) if @icon %>
+        </summary>
+      ERB
+
+      private
+
+      def classes
+        class_names(
+          'flex items-center justify-between gap-3 py-3.5 font-medium cursor-pointer',
+          @options[:class]
+        )
+      end
+
+      def icon_classes
+        'transition-transform size-4 group-open:-rotate-180'
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/clipboard/component.rb
+++ b/app/components/jet_ui/clipboard/component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Clipboard
+    class Component < JetUi::BaseComponent
+      def initialize(as: nil, value: nil, source_id: nil, success_text: 'Copied!',
+                     tooltip: nil, tooltip_success: nil, tooltip_placement: 'top', **options)
+        @as = as
+        @value = value
+        @source_id = source_id
+        @success_text = success_text
+        @tooltip = tooltip
+        @tooltip_success = tooltip_success || success_text
+        @tooltip_placement = tooltip_placement
+        @options = options
+      end
+
+      def call
+        if @as
+          helpers.jet_ui.public_send(@as, **attrs) { content }
+        else
+          content_tag :span, content, class: classes, **attrs
+        end
+      end
+
+      private
+
+      def attrs
+        @options.except(:class, :data).merge(data: data_attributes)
+      end
+
+      def data_attributes
+        base = {
+          controller: @tooltip ? 'clipboard tooltip' : 'clipboard',
+          clipboard_success_text_value: @success_text,
+          action: @tooltip ? 'click->clipboard#copy clipboard:change->tooltip#updateContent' : 'click->clipboard#copy'
+        }
+
+        base[:clipboard_content_value] = @value if @value
+        base[:clipboard_source_id_value] = @source_id if @source_id
+        base.merge!(tooltip_attributes) if @tooltip
+        base.merge(@options.fetch(:data, {}))
+      end
+
+      def tooltip_attributes
+        {
+          tooltip_content_value: @tooltip,
+          tooltip_placement_value: @tooltip_placement,
+          clipboard_success_text_value: @success_text
+        }
+      end
+
+      def classes
+        class_names('cursor-pointer', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/drawer/body_component.rb
+++ b/app/components/jet_ui/drawer/body_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Drawer
+    class BodyComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('drawer__body', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/drawer/component.rb
+++ b/app/components/jet_ui/drawer/component.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Drawer
+    class Component < JetUi::BaseComponent
+      SIZES = %w[sm md lg xl 2xl 3xl 4xl 5xl 6xl].freeze
+      DEFAULT_SIZE = '2xl'
+
+      def initialize(title: nil, subtitle: nil, size: DEFAULT_SIZE, id: nil)
+        @title = title
+        @subtitle = subtitle
+        @size = size
+        @id = id
+      end
+
+      erb_template <<~ERB
+        <%= container_tag do %>
+          <%= helpers.jet_ui.drawer_header(title: @title, subtitle: @subtitle, closable: closable?, id: @id) %>
+          <%= content %>
+        <% end %>
+      ERB
+
+      private
+
+      def container_tag(&block)
+        return sync_dialog(&block) if @id
+        return turbo_frame_dialog(&block) if helpers.turbo_frame_request?
+
+        content_tag :div, class: class_names('mx-auto bg-background', "w-#{@size}"), &block
+      end
+
+      def sync_dialog(&block)
+        dialog_tag(id: @id, data: { drawers_target: 'dialog' }, &block)
+      end
+
+      def turbo_frame_dialog(&block)
+        helpers.turbo_frame_tag :drawer do
+          dialog_tag(id: :drawerDialog, data: { controller: 'drawer' }) do
+            helpers.turbo_frame_tag(:drawerContent, &block)
+          end
+        end
+      end
+
+      def dialog_tag(**options, &block)
+        attrs = { tabindex: '-1', class: class_names('drawer', 'animate-slide-left', "w-#{@size}") }
+        content_tag :dialog, **attrs, **options, &block
+      end
+
+      def closable?
+        helpers.turbo_frame_request? || @id
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/drawer/footer_component.rb
+++ b/app/components/jet_ui/drawer/footer_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Drawer
+    class FooterComponent < JetUi::BaseComponent
+      def initialize(direction: :row, align: :start, justify: :start, bordered: true, **options)
+        @direction = direction
+        @align = align
+        @justify = justify
+        @bordered = bordered
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names(
+          'drawer__footer',
+          { 'drawer__footer-bordered' => @bordered },
+          direction_class,
+          align_class,
+          justify_class,
+          @options[:class]
+        )
+      end
+
+      def direction_class
+        { col: 'flex flex-col gap-2', row: 'flex flex-row gap-2' }[@direction]
+      end
+
+      def align_class
+        { start: 'items-start', center: 'items-center', end: 'items-end' }[@align]
+      end
+
+      def justify_class
+        { start: 'justify-start', center: 'justify-center', end: 'justify-end',
+          between: 'justify-between' }[@justify]
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/drawer/header_component.rb
+++ b/app/components/jet_ui/drawer/header_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Drawer
+    class HeaderComponent < JetUi::BaseComponent
+      def initialize(title: nil, subtitle: nil, closable: true, id: nil, bordered: true, **options)
+        @title = title
+        @subtitle = subtitle
+        @closable = closable
+        @id = id
+        @bordered = bordered
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <div class="<%= classes %>">
+          <div>
+            <% if @title %>
+              <h3 class="drawer__title"><%= @title %></h3>
+            <% end %>
+            <% if @subtitle %>
+              <div class="drawer__subtitle"><%= @subtitle %></div>
+            <% end %>
+            <%= content %>
+          </div>
+
+          <% if @closable %>
+            <button type="button" class="drawer__close" data-action="click->drawer#close click->drawers#close" aria-label="Close" data-id="<%= @id %>">
+              <%= helpers.jet_ui.icon("x-mark", size: 6) %>
+            </button>
+          <% end %>
+        </div>
+      ERB
+
+      private
+
+      def classes
+        class_names(
+          'drawer__header',
+          { 'drawer__header-bordered' => @bordered },
+          @options[:class]
+        )
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/button_component.rb
+++ b/app/components/jet_ui/dropdown/button_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class ButtonComponent < JetUi::BaseComponent
+      def initialize(href: nil, **options)
+        @href = href
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <li class="dropdown__item">
+          <%= button_to content, @href, **@options.except(:class), class: classes, form: { class: "dropdown__form" } %>
+        </li>
+      ERB
+
+      private
+
+      def classes
+        class_names('dropdown__link', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/component.rb
+++ b/app/components/jet_ui/dropdown/component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class Component < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <%= content_tag :div, class: classes, **attrs do %>
+          <%= content %>
+        <% end %>
+      ERB
+
+      private
+
+      def attrs
+        data_attributes = { controller: 'dropdown' }.deep_merge(@options.fetch(:data, {}))
+        @options.except(:class, :data).merge(data: data_attributes)
+      end
+
+      def classes
+        class_names('dropdown', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/divider_component.rb
+++ b/app/components/jet_ui/dropdown/divider_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class DividerComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :li, nil, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('dropdown__divider', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/link_component.rb
+++ b/app/components/jet_ui/dropdown/link_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class LinkComponent < JetUi::BaseComponent
+      def initialize(url: nil, active: false, **options)
+        @url = url
+        @active = active
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <li class="dropdown__item">
+          <%= link_to content, @url, class: classes, **@options.except(:class) %>
+        </li>
+      ERB
+
+      private
+
+      def classes
+        class_names(
+          'dropdown__link',
+          ('dropdown__link-active' if @active),
+          @options[:class]
+        )
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/menu_component.rb
+++ b/app/components/jet_ui/dropdown/menu_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class MenuComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <div class="dropdown__menu" data-dropdown-target="menu">
+          <ul class="<%= classes %>">
+            <%= content %>
+          </ul>
+        </div>
+      ERB
+
+      private
+
+      def classes
+        class_names('dropdown__wrapper', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/title_component.rb
+++ b/app/components/jet_ui/dropdown/title_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class TitleComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :h6, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('dropdown__title', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dropdown/trigger_component.rb
+++ b/app/components/jet_ui/dropdown/trigger_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dropdown
+    class TriggerComponent < JetUi::BaseComponent
+      def initialize(as: nil, **options)
+        @as = as
+        @options = options
+        @options[:data] ||= {}
+        @options[:data][:dropdown_target] = 'trigger'
+      end
+
+      def call
+        if @as
+          helpers.jet_ui.public_send(@as, **@options) { content }
+        else
+          content_tag :span, content, role: :button, class: classes, **@options.except(:class)
+        end
+      end
+
+      private
+
+      def classes
+        class_names('dropdown__trigger', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/header/actions_component.rb
+++ b/app/components/jet_ui/header/actions_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Header
+    class ActionsComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('header__actions', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/header/component.rb
+++ b/app/components/jet_ui/header/component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Header
+    class Component < JetUi::BaseComponent
+      def initialize(direction: :row, align: :start, justify: :between,
+                     sticky: false, bordered: false, **options)
+        @direction = direction
+        @align = align
+        @justify = justify
+        @sticky = sticky
+        @bordered = bordered
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names(
+          'header',
+          "header--#{@direction}",
+          "header--align-#{@align}",
+          "header--justify-#{@justify}",
+          { 'header--sticky' => @sticky },
+          { 'header--bordered' => @bordered },
+          @options[:class]
+        )
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/header/heading_component.rb
+++ b/app/components/jet_ui/header/heading_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Header
+    class HeadingComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('header__heading', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/header/subtitle_component.rb
+++ b/app/components/jet_ui/header/subtitle_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Header
+    class SubtitleComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :p, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('header__subtitle', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/header/title_component.rb
+++ b/app/components/jet_ui/header/title_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Header
+    class TitleComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :h1, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('header__title', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/modal/body_component.rb
+++ b/app/components/jet_ui/modal/body_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Modal
+    class BodyComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('modal__body', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/modal/component.rb
+++ b/app/components/jet_ui/modal/component.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Modal
+    class Component < JetUi::BaseComponent
+      SIZES = %w[sm md lg xl 2xl 3xl 4xl 5xl 6xl].freeze
+      DEFAULT_SIZE = '2xl'
+
+      def initialize(title: nil, subtitle: nil, size: DEFAULT_SIZE, id: nil)
+        @title = title
+        @subtitle = subtitle
+        @size = size
+        @id = id
+      end
+
+      erb_template <<~ERB
+        <%= container_tag do %>
+          <%= helpers.jet_ui.modal_header(title: @title, subtitle: @subtitle, closable: closable?, id: @id) %>
+          <%= content %>
+        <% end %>
+      ERB
+
+      private
+
+      def container_tag(&block)
+        return sync_dialog(&block) if @id
+        return turbo_frame_dialog(&block) if helpers.turbo_frame_request?
+
+        content_tag :div, class: class_names('modal modal-page', "w-#{@size}"), &block
+      end
+
+      def sync_dialog(&block)
+        dialog_tag(id: @id, data: { modals_target: 'dialog' }, &block)
+      end
+
+      def turbo_frame_dialog(&block)
+        helpers.turbo_frame_tag :modal do
+          dialog_tag(id: :modalDialog, data: { controller: 'modal' }) do
+            helpers.turbo_frame_tag(:modalContent, &block)
+          end
+        end
+      end
+
+      def dialog_tag(**options, &block)
+        attrs = { tabindex: '-1', class: class_names('modal', 'animate-slide-up', "w-#{@size}") }
+        content_tag :dialog, **attrs, **options, &block
+      end
+
+      def closable?
+        helpers.turbo_frame_request? || @id
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/modal/footer_component.rb
+++ b/app/components/jet_ui/modal/footer_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Modal
+    class FooterComponent < JetUi::BaseComponent
+      def initialize(direction: :row, align: :start, justify: :start, bordered: true, **options)
+        @direction = direction
+        @align = align
+        @justify = justify
+        @bordered = bordered
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names(
+          'modal__footer',
+          { 'modal__footer-bordered' => @bordered },
+          direction_class,
+          align_class,
+          justify_class,
+          @options[:class]
+        )
+      end
+
+      def direction_class
+        { col: 'flex flex-col gap-2', row: 'flex flex-row gap-2' }[@direction]
+      end
+
+      def align_class
+        { start: 'items-start', center: 'items-center', end: 'items-end' }[@align]
+      end
+
+      def justify_class
+        { start: 'justify-start', center: 'justify-center', end: 'justify-end',
+          between: 'justify-between' }[@justify]
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/modal/header_component.rb
+++ b/app/components/jet_ui/modal/header_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Modal
+    class HeaderComponent < JetUi::BaseComponent
+      def initialize(title: nil, subtitle: nil, closable: true, id: nil, bordered: true, **options)
+        @title = title
+        @subtitle = subtitle
+        @closable = closable
+        @id = id
+        @bordered = bordered
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <div class="<%= classes %>">
+          <div>
+            <% if @title %>
+              <h3 class="modal__title"><%= @title %></h3>
+            <% end %>
+            <% if @subtitle %>
+              <div class="modal__subtitle"><%= @subtitle %></div>
+            <% end %>
+            <%= content %>
+          </div>
+
+          <% if @closable %>
+            <button type="button" class="modal__close" data-action="click->modal#close click->modals#close" aria-label="Close" data-id="<%= @id %>">
+              <%= helpers.jet_ui.icon("x-mark", size: 6) %>
+            </button>
+          <% end %>
+        </div>
+      ERB
+
+      private
+
+      def classes
+        class_names(
+          'modal__header',
+          { 'modal__header-bordered' => @bordered },
+          @options[:class]
+        )
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/navbar/actions_component.rb
+++ b/app/components/jet_ui/navbar/actions_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Navbar
+    class ActionsComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:div, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('navbar__actions', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/navbar/brand_component.rb
+++ b/app/components/jet_ui/navbar/brand_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Navbar
+    class BrandComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:div, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('navbar__brand', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/navbar/component.rb
+++ b/app/components/jet_ui/navbar/component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Navbar
+    class Component < JetUi::BaseComponent
+      def initialize(sticky: true, **options)
+        @sticky = sticky
+        @options = options
+      end
+
+      def call
+        content_tag(:header, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('navbar', { 'navbar-sticky' => @sticky }, @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/navbar/content_component.rb
+++ b/app/components/jet_ui/navbar/content_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Navbar
+    class ContentComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:div, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('navbar__content', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/navbar/main_component.rb
+++ b/app/components/jet_ui/navbar/main_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Navbar
+    class MainComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:div, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('navbar__main', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/popover/component.rb
+++ b/app/components/jet_ui/popover/component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Popover
+    class Component < JetUi::BaseComponent
+      def initialize(placement: :bottom, **options)
+        @placement = placement
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <%= content_tag :div, **attrs, class: 'w-fit' do %>
+          <%= content %>
+        <% end %>
+      ERB
+
+      private
+
+      def attrs
+        data_attributes = {
+          controller: 'popover',
+          popover_placement_value: @placement
+        }.deep_merge(@options.fetch(:data, {}))
+
+        @options.except(:data).merge(data: data_attributes)
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/popover/content_component.rb
+++ b/app/components/jet_ui/popover/content_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Popover
+    class ContentComponent < JetUi::BaseComponent
+      def initialize(title: nil, **options)
+        @title = title
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <%= content_tag :div, class: "popover", data: { popover_target: "content" }, **@options.except(:class, :data) do %>
+          <% if @title %>
+            <div class="popover__title"><%= @title %></div>
+          <% end %>
+          <div class="popover__body">
+            <%= content %>
+          </div>
+        <% end %>
+      ERB
+    end
+  end
+end

--- a/app/components/jet_ui/popover/trigger_component.rb
+++ b/app/components/jet_ui/popover/trigger_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Popover
+    class TriggerComponent < JetUi::BaseComponent
+      def initialize(as: nil, **options)
+        @as = as
+        @options = options
+      end
+
+      def call
+        if @as
+          helpers.jet_ui.public_send(@as, **@options) { content }
+        else
+          content_tag :span, content, **@options
+        end
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/sidebar/component.rb
+++ b/app/components/jet_ui/sidebar/component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Sidebar
+    class Component < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:nav, content, class: classes, **data_attributes, **@options.except(:class, :data))
+      end
+
+      private
+
+      def classes
+        class_names('sidebar', @options[:class])
+      end
+
+      def data_attributes
+        default_data = { sidebar_target: 'menu' }
+        custom_data = @options[:data] || {}
+        { data: default_data.merge(custom_data) }
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/sidebar/link_component.rb
+++ b/app/components/jet_ui/sidebar/link_component.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Sidebar
+    class LinkComponent < JetUi::BaseComponent
+      def initialize(url: nil, disabled: false, active: nil, **options)
+        @url = url
+        @disabled = disabled
+        @active = active
+        @options = options
+      end
+
+      erb_template <<~ERB
+        <li>
+          <% if @disabled %>
+            <span class="<%= classes %>"><%= content %></span>
+          <% else %>
+            <%= link_to @url, class: classes, **@options.except(:class) do %>
+              <%= content %>
+            <% end %>
+          <% end %>
+        </li>
+      ERB
+
+      private
+
+      def classes
+        class_names(
+          'sidebar__link',
+          ('sidebar__link-active' if active?),
+          ('sidebar__link-disabled' if @disabled),
+          @options[:class]
+        )
+      end
+
+      def active?
+        return @active unless @active.nil?
+        return false if @url.nil? || @disabled
+
+        helpers.current_page?(@url)
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/sidebar/menu_component.rb
+++ b/app/components/jet_ui/sidebar/menu_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Sidebar
+    class MenuComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:ul, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('sidebar__menu', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/sidebar/section_component.rb
+++ b/app/components/jet_ui/sidebar/section_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Sidebar
+    class SectionComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:div, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('sidebar__section', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/sidebar/title_component.rb
+++ b/app/components/jet_ui/sidebar/title_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Sidebar
+    class TitleComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag(:h4, content, class: classes, **@options.except(:class))
+      end
+
+      private
+
+      def classes
+        class_names('sidebar__title', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/tooltip/component.rb
+++ b/app/components/jet_ui/tooltip/component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Tooltip
+    class Component < JetUi::BaseComponent
+      def initialize(title:, as: nil, placement: :top, **options)
+        @as = as
+        @title = title
+        @placement = placement
+        @options = options
+      end
+
+      def call
+        if @as
+          helpers.jet_ui.public_send(@as, **attrs) { content }
+        else
+          content_tag :span, content, class: 'w-fit', **attrs
+        end
+      end
+
+      private
+
+      def attrs
+        data_attributes = {
+          controller: 'tooltip',
+          tooltip_content_value: @title,
+          tooltip_placement_value: @placement
+        }.deep_merge(@options.fetch(:data, {}))
+
+        @options.except(:data).merge(data: data_attributes)
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/turbo_confirm/component.html.erb
+++ b/app/components/jet_ui/turbo_confirm/component.html.erb
@@ -1,0 +1,20 @@
+<dialog id="turbo-confirm" tabindex="-1"
+        class="modal w-2xl animate-slide-up"
+        data-controller="turbo-confirm">
+  <form method="dialog">
+    <div class="modal__header modal__header-bordered">
+      <div>
+        <h3 class="modal__title">Are you absolutely sure?</h3>
+      </div>
+    </div>
+
+    <div class="modal__body">
+      <p>This cannot be undone.</p>
+    </div>
+
+    <div class="modal__footer modal__footer-bordered flex flex-row gap-2 items-start justify-end">
+      <%= helpers.jet_ui.btn "Cancel", type: :submit, variant: :outline, value: "cancel" %>
+      <%= helpers.jet_ui.btn "Yes, I'm sure", type: :submit, variant: :danger, value: "confirm" %>
+    </div>
+  </form>
+</dialog>

--- a/app/components/jet_ui/turbo_confirm/component.rb
+++ b/app/components/jet_ui/turbo_confirm/component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module JetUi
+  module TurboConfirm
+    class Component < JetUi::BaseComponent
+    end
+  end
+end

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -1,0 +1,57 @@
+# Accordion
+
+Collapsible content sections built on the native HTML `<details>` / `<summary>` elements. No JavaScript required.
+
+## Examples
+
+```erb
+<%# Basic %>
+<%= jet_ui.accordion do %>
+  <%= jet_ui.accordion_summary { "What is JetUi?" } %>
+  <%= jet_ui.accordion_body { "A ViewComponent-based UI library for Rails." } %>
+<% end %>
+
+<%# Open by default %>
+<%= jet_ui.accordion(open: true) do %>
+  <%= jet_ui.accordion_summary { "Already open" } %>
+  <%= jet_ui.accordion_body { "This panel starts expanded." } %>
+<% end %>
+
+<%# Exclusive group — only one open at a time (native browser behaviour) %>
+<%= jet_ui.accordion(name: "faq") do %>
+  <%= jet_ui.accordion_summary { "Question 1" } %>
+  <%= jet_ui.accordion_body { "Answer 1" } %>
+<% end %>
+
+<%= jet_ui.accordion(name: "faq") do %>
+  <%= jet_ui.accordion_summary { "Question 2" } %>
+  <%= jet_ui.accordion_body { "Answer 2" } %>
+<% end %>
+
+<%# No chevron icon %>
+<%= jet_ui.accordion do %>
+  <%= jet_ui.accordion_summary(icon: nil) { "Custom header" } %>
+  <%= jet_ui.accordion_body { "Content" } %>
+<% end %>
+```
+
+## Parameters
+
+### `accordion`
+
+| Parameter   | Type    | Default | Description                                                     |
+|-------------|---------|---------|------------------------------------------------------------------|
+| `open`      | Boolean | `false` | Renders the panel expanded by default.                          |
+| `name`      | String  | `nil`   | Groups accordions — only one with the same `name` stays open.   |
+| `**options` | Hash    | `{}`    | HTML attributes on the `<details>` element.                     |
+
+### `accordion_summary`
+
+| Parameter   | Type   | Default          | Description                                      |
+|-------------|--------|------------------|--------------------------------------------------|
+| `icon`      | String | `'chevron-down'` | Icon name shown at the right. Pass `nil` to hide. |
+| `**options` | Hash   | `{}`             | HTML attributes on the `<summary>` element.      |
+
+### `accordion_body`
+
+No parameters. Renders a `<div>` wrapping the block content.

--- a/docs/components/clipboard.md
+++ b/docs/components/clipboard.md
@@ -1,0 +1,45 @@
+# Clipboard
+
+Copy-to-clipboard component powered by the browser's native `navigator.clipboard` API. Supports optional tooltip feedback and rendering as any other JetUi component.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Wrap any content — click copies the value %>
+<%= jet_ui.clipboard(value: "npm install jet_ui") do %>
+  <code>npm install jet_ui</code>
+<% end %>
+
+<%# Copy text from another element by ID %>
+<%= jet_ui.clipboard(source_id: "my-input") do %>
+  Copy
+<% end %>
+<input id="my-input" value="Hello world">
+
+<%# Render as a button %>
+<%= jet_ui.clipboard(as: :btn, value: "secret", variant: :outline) { "Copy token" } %>
+
+<%# With tooltip feedback %>
+<%= jet_ui.clipboard(value: "Hello", tooltip: "Copy", tooltip_success: "Copied!") do %>
+  Copy
+<% end %>
+```
+
+## Parameters
+
+| Parameter          | Type   | Default     | Description                                                                     |
+|--------------------|--------|-------------|---------------------------------------------------------------------------------|
+| `value`            | String | `nil`       | Text to copy. If nil, `source_id` is used.                                      |
+| `source_id`        | String | `nil`       | ID of a DOM element whose value/text is copied.                                 |
+| `success_text`     | String | `'Copied!'` | Text restored to the element after the copy (when no tooltip is used).          |
+| `as`               | Symbol | `nil`       | Render as another JetUi helper (e.g. `:btn`). Extra options are passed through. |
+| `tooltip`          | String | `nil`       | Initial tooltip text. Enables tooltip integration when set.                     |
+| `tooltip_success`  | String | `nil`       | Tooltip text shown after a successful copy. Defaults to `success_text`.         |
+| `tooltip_placement`| String | `'top'`     | Tooltip placement: `top`, `bottom`, `left`, `right`.                            |
+| `**options`        | Hash   | `{}`        | HTML attributes on the wrapper element.                                         |
+
+## Stimulus controller
+
+The `clipboard` Stimulus controller handles the copy action and success feedback. When a `tooltip` is provided, it co-operates with the `tooltip` controller via a `clipboard:change` event.

--- a/docs/components/drawer.md
+++ b/docs/components/drawer.md
@@ -1,0 +1,77 @@
+# Drawer
+
+Slide-in panel component. Slides in from the right. Supports the same two rendering modes as Modal:
+
+- **Async (Turbo Frame)** — open via a Turbo Frame request; renders a `<turbo-frame id="drawer">` wrapping a `<dialog>` controlled by the `drawer` Stimulus controller.
+- **Sync** — pass an `id:` and place a `data-controller="drawers"` wrapper on the page; open by dispatching a click on any element with `data-action="click->drawers#open" data-id="your-id"`.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Async via Turbo Frame %>
+<%= jet_ui.drawer(title: "User details") do %>
+  <%= jet_ui.drawer_body do %>
+    <%= render "users/detail", user: @user %>
+  <% end %>
+<% end %>
+
+<%# Sync %>
+<div data-controller="drawers">
+  <button data-action="click->drawers#open" data-id="filters-drawer">Filters</button>
+
+  <%= jet_ui.drawer(id: "filters-drawer", title: "Filters") do %>
+    <%= jet_ui.drawer_body do %>
+      <%= render "filters_form" %>
+    <% end %>
+    <%= jet_ui.drawer_footer do %>
+      <%= jet_ui.btn "Apply" %>
+    <% end %>
+  <% end %>
+</div>
+
+<%# Custom size %>
+<%= jet_ui.drawer(title: "Wide panel", size: "4xl") do %>
+  ...
+<% end %>
+```
+
+## Parameters
+
+### `drawer`
+
+| Parameter  | Type   | Default | Description                                                                                     |
+|------------|--------|---------|-------------------------------------------------------------------------------------------------|
+| `title`    | String | `nil`   | Header title text.                                                                              |
+| `subtitle` | String | `nil`   | Header subtitle text.                                                                           |
+| `size`     | String | `'2xl'` | Width token: `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.                       |
+| `id`       | String | `nil`   | Enables sync mode. Must match the `data-id` on the trigger button.                              |
+
+### `drawer_header`
+
+| Parameter  | Type    | Default | Description                                         |
+|------------|---------|---------|-----------------------------------------------------|
+| `title`    | String  | `nil`   | Title text.                                         |
+| `subtitle` | String  | `nil`   | Subtitle text.                                      |
+| `closable` | Boolean | `true`  | Shows the close button.                             |
+| `id`       | String  | `nil`   | Passed to the close button's `data-id` attribute.   |
+
+### `drawer_body`
+
+Wrapper for drawer content. Accepts `**options` (HTML attributes).
+
+### `drawer_footer`
+
+Wrapper for drawer actions. Accepts `**options` (HTML attributes).
+
+## CSS classes
+
+| Class            | Description                      |
+|------------------|----------------------------------|
+| `.drawer`        | Root dialog element              |
+| `.drawer__header`| Header area                      |
+| `.drawer__title` | Title `<h3>`                     |
+| `.drawer__close` | Close button                     |
+| `.drawer__body`  | Content area                     |
+| `.drawer__footer`| Footer area                      |

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -1,0 +1,84 @@
+# Dropdown
+
+Context menu component. Clicking the trigger toggles the menu open/closed. Clicking outside closes it. Menu position flips automatically when near viewport edges.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Basic %>
+<%= jet_ui.dropdown do %>
+  <%= jet_ui.dropdown_trigger { "Options" } %>
+  <%= jet_ui.dropdown_menu do %>
+    <%= jet_ui.dropdown_link "Edit", href: edit_path %>
+    <%= jet_ui.dropdown_link "Duplicate", href: duplicate_path %>
+    <%= jet_ui.dropdown_divider %>
+    <%= jet_ui.dropdown_button "Delete", data: { action: "click->modal#open" } %>
+  <% end %>
+<% end %>
+
+<%# Trigger rendered as a button component %>
+<%= jet_ui.dropdown do %>
+  <%= jet_ui.dropdown_trigger(as: :btn, variant: :outline, size: :sm) { "Actions" } %>
+  <%= jet_ui.dropdown_menu do %>
+    <%= jet_ui.dropdown_title { "Manage" } %>
+    <%= jet_ui.dropdown_link "Settings", href: settings_path %>
+  <% end %>
+<% end %>
+```
+
+## Parameters
+
+### `dropdown`
+
+| Parameter   | Type | Default | Description                              |
+|-------------|------|---------|------------------------------------------|
+| `**options` | Hash | `{}`    | HTML attributes on the wrapper `<div>`.  |
+
+Always renders `data-controller="dropdown"`.
+
+### `dropdown_trigger`
+
+| Parameter   | Type   | Default | Description                                                              |
+|-------------|--------|---------|--------------------------------------------------------------------------|
+| `as`        | Symbol | `nil`   | Render as another JetUi component (e.g. `:btn`). Options are forwarded.  |
+| `**options` | Hash   | `{}`    | HTML attributes. `data-dropdown-target="trigger"` is added automatically.|
+
+### `dropdown_menu`
+
+Wrapper for menu items. Accepts `**options` (HTML attributes on the inner `<ul>`).
+
+### `dropdown_link`
+
+| Parameter   | Type   | Default | Description                                         |
+|-------------|--------|---------|-----------------------------------------------------|
+| `label`     | String | —       | Link text (positional argument).                    |
+| `**options` | Hash   | `{}`    | HTML attributes on the `<a>` element (include `href`). |
+
+### `dropdown_button`
+
+| Parameter   | Type   | Default | Description                               |
+|-------------|--------|---------|-------------------------------------------|
+| `label`     | String | —       | Button text (positional argument).        |
+| `**options` | Hash   | `{}`    | HTML attributes on the `<button>` element.|
+
+### `dropdown_title`
+
+Section label. Accepts block content. No additional parameters.
+
+### `dropdown_divider`
+
+Horizontal rule separator. No parameters.
+
+## CSS classes
+
+| Class               | Description                       |
+|---------------------|-----------------------------------|
+| `.dropdown`         | Root container                    |
+| `.dropdown__trigger`| Trigger element                   |
+| `.dropdown__menu`   | Floating menu container           |
+| `.dropdown__wrapper`| Inner `<ul>` list                 |
+| `.dropdown__item`   | Individual menu item              |
+| `.dropdown__title`  | Section label                     |
+| `.dropdown__divider`| Separator rule                    |

--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -1,0 +1,65 @@
+# Header
+
+Page-level header component for titles, subtitles, and action buttons. Supports responsive direction, alignment, sticky positioning, and an optional bottom border.
+
+## Examples
+
+```erb
+<%# Basic %>
+<%= jet_ui.header do %>
+  <%= jet_ui.header_heading do %>
+    <%= jet_ui.header_title { "Users" } %>
+    <%= jet_ui.header_subtitle { "Manage your team members." } %>
+  <% end %>
+  <%= jet_ui.header_actions do %>
+    <%= jet_ui.btn "New user", href: new_user_path %>
+  <% end %>
+<% end %>
+
+<%# Sticky with border %>
+<%= jet_ui.header(sticky: true, bordered: true) do %>
+  <%= jet_ui.header_heading do %>
+    <%= jet_ui.header_title { "Settings" } %>
+  <% end %>
+<% end %>
+
+<%# Column direction (title above actions, no responsive breakpoint) %>
+<%= jet_ui.header(direction: :col) do %>
+  <%= jet_ui.header_heading do %>
+    <%= jet_ui.header_title { "Report" } %>
+    <%= jet_ui.header_subtitle { "Last updated today" } %>
+  <% end %>
+  <%= jet_ui.header_actions do %>
+    <%= jet_ui.btn "Export", variant: :outline %>
+  <% end %>
+<% end %>
+```
+
+## Parameters
+
+### `header`
+
+| Parameter   | Type    | Default   | Description                                                                                |
+|-------------|---------|-----------|--------------------------------------------------------------------------------------------|
+| `direction` | Symbol  | `:row`    | Layout direction: `:row` (stacks vertically on mobile, horizontal on `md+`) or `:col`.    |
+| `align`     | Symbol  | `:start`  | Cross-axis alignment: `:start`, `:center`, `:end`.                                         |
+| `justify`   | Symbol  | `:between`| Main-axis distribution: `:start`, `:center`, `:end`, `:between`.                           |
+| `sticky`    | Boolean | `false`   | Sticks to top of viewport on `lg+` with a blurred background.                              |
+| `bordered`  | Boolean | `false`   | Adds a bottom border and extra bottom padding.                                              |
+| `**options` | Hash    | `{}`      | HTML attributes on the wrapper `<div>`.                                                     |
+
+### `header_heading`
+
+Flexible column container for title/subtitle. Accepts `**options` (HTML attributes on the `<div>`).
+
+### `header_title`
+
+Renders the page title. Accepts `**options` (HTML attributes on the element).
+
+### `header_subtitle`
+
+Renders a subtitle below the title. Accepts `**options` (HTML attributes on the element).
+
+### `header_actions`
+
+Right-aligned slot for buttons and controls. Accepts `**options` (HTML attributes on the wrapper `<div>`).

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,0 +1,85 @@
+# Modal
+
+Dialog overlay component. Supports two rendering modes:
+
+- **Async (Turbo Frame)** — open via a Turbo Frame request; the modal wraps itself in a `<turbo-frame id="modal">` and renders a `<dialog>` controlled by the `modal` Stimulus controller.
+- **Sync** — pass an `id:` and place a `data-controller="modals"` wrapper on the page; open by dispatching a click on any element with `data-action="click->modals#open" data-id="your-id"`.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Async via Turbo Frame (in a partial loaded into turbo_frame_tag :modal) %>
+<%= jet_ui.modal(title: "Edit User") do %>
+  <%= jet_ui.modal_body do %>
+    <%= render "form", user: @user %>
+  <% end %>
+  <%= jet_ui.modal_footer do %>
+    <%= jet_ui.btn "Save", type: :submit, form: "edit_user_form" %>
+  <% end %>
+<% end %>
+
+<%# Sync — button + pre-rendered dialog on the same page %>
+<div data-controller="modals">
+  <button data-action="click->modals#open" data-id="confirm-modal">Delete</button>
+
+  <%= jet_ui.modal(id: "confirm-modal", title: "Are you sure?") do %>
+    <%= jet_ui.modal_body { "This action cannot be undone." } %>
+    <%= jet_ui.modal_footer do %>
+      <%= jet_ui.btn "Cancel", variant: :outline,
+            data: { action: "click->modals#close", id: "confirm-modal" } %>
+      <%= jet_ui.btn "Delete", variant: :danger %>
+    <% end %>
+  <% end %>
+</div>
+
+<%# Custom size %>
+<%= jet_ui.modal(title: "Wide modal", size: "4xl") do %>
+  ...
+<% end %>
+```
+
+## Parameters
+
+### `modal`
+
+| Parameter  | Type   | Default | Description                                                                                     |
+|------------|--------|---------|-------------------------------------------------------------------------------------------------|
+| `title`    | String | `nil`   | Header title text.                                                                              |
+| `subtitle` | String | `nil`   | Header subtitle text.                                                                           |
+| `size`     | String | `'2xl'` | Max-width token: `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.                   |
+| `id`       | String | `nil`   | Enables sync mode. Must match the `data-id` on the trigger button.                              |
+
+### `modal_header`
+
+| Parameter  | Type    | Default | Description                                         |
+|------------|---------|---------|-----------------------------------------------------|
+| `title`    | String  | `nil`   | Title text.                                         |
+| `subtitle` | String  | `nil`   | Subtitle text.                                      |
+| `closable` | Boolean | `true`  | Shows the close button.                             |
+| `bordered` | Boolean | `true`  | Adds a bottom border to the header.                 |
+| `id`       | String  | `nil`   | Passed to the close button's `data-id` attribute.   |
+
+### `modal_body`
+
+Wrapper for modal content. Accepts `**options` (HTML attributes).
+
+### `modal_footer`
+
+Wrapper for modal actions. Accepts `**options` (HTML attributes).
+
+## CSS classes
+
+| Class                      | Description                    |
+|----------------------------|--------------------------------|
+| `.modal`                   | Root dialog/container element  |
+| `.modal-page`              | Non-dialog inline variant      |
+| `.modal__header`           | Header area                    |
+| `.modal__header-bordered`  | Header with bottom border      |
+| `.modal__title`            | Title `<h3>`                   |
+| `.modal__subtitle`         | Subtitle element               |
+| `.modal__close`            | Close button                   |
+| `.modal__body`             | Content area                   |
+| `.modal__footer`           | Footer area                    |
+| `.modal__footer-bordered`  | Footer with top border         |

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -1,0 +1,66 @@
+# Navbar
+
+Top navigation bar component. Sticky by default. Pairs naturally with the Sidebar component for full app shell layouts.
+
+## Examples
+
+```erb
+<%# Basic %>
+<%= jet_ui.navbar do %>
+  <%= jet_ui.navbar_brand do %>
+    <%= link_to root_path do %>
+      <%= image_tag "logo.svg", height: 28 %>
+    <% end %>
+  <% end %>
+
+  <%= jet_ui.navbar_content do %>
+    <%= jet_ui.navbar_main do %>
+      <%= link_to "Dashboard", root_path %>
+      <%= link_to "Reports", reports_path %>
+    <% end %>
+
+    <%= jet_ui.navbar_actions do %>
+      <%= jet_ui.btn "Sign out", href: sign_out_path, variant: :outline, size: :sm %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%# Non-sticky %>
+<%= jet_ui.navbar(sticky: false) do %>
+  ...
+<% end %>
+```
+
+## Parameters
+
+### `navbar`
+
+| Parameter   | Type    | Default | Description                                             |
+|-------------|---------|---------|----------------------------------------------------------|
+| `sticky`    | Boolean | `true`  | Fixes the navbar to the top of the viewport.            |
+| `**options` | Hash    | `{}`    | HTML attributes on the `<header>` element.              |
+
+### `navbar_brand`
+
+Left-aligned brand/logo slot. Accepts `**options` (HTML attributes on the wrapper `<div>`).
+
+### `navbar_content`
+
+Flex container for the rest of the navbar (main nav + actions). Accepts `**options`.
+
+### `navbar_main`
+
+Center/left nav links area. Accepts `**options` (HTML attributes on the wrapper `<div>`).
+
+### `navbar_actions`
+
+Right-aligned actions slot (buttons, user avatar, etc.). Accepts `**options`.
+
+## CSS classes
+
+| Class            | Description                                     |
+|------------------|-------------------------------------------------|
+| `.navbar`        | Root `<header>` element                         |
+| `.navbar-sticky` | Added when `sticky: true`                       |
+| `.navbar__brand` | Brand/logo area                                 |
+| `.navbar__content`| Content flex container                         |

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -1,0 +1,64 @@
+# Popover
+
+Rich hover panel component. Shows a floating content card when hovering over the trigger element. Position flips automatically when near viewport edges.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Basic %>
+<%= jet_ui.popover do %>
+  <%= jet_ui.popover_trigger { "Hover me" } %>
+  <%= jet_ui.popover_content(title: "Details") do %>
+    <p>More information goes here.</p>
+  <% end %>
+<% end %>
+
+<%# Custom placement %>
+<%= jet_ui.popover(placement: :right) do %>
+  <%= jet_ui.popover_trigger { "Info" } %>
+  <%= jet_ui.popover_content do %>
+    <p>Shown on the right.</p>
+  <% end %>
+<% end %>
+
+<%# Trigger rendered as a button %>
+<%= jet_ui.popover do %>
+  <%= jet_ui.popover_trigger(as: :btn, variant: :outline, size: :sm) { "Details" } %>
+  <%= jet_ui.popover_content(title: "Summary") do %>
+    Some rich content here.
+  <% end %>
+<% end %>
+```
+
+## Parameters
+
+### `popover`
+
+| Parameter   | Type          | Default    | Description                                                          |
+|-------------|---------------|------------|----------------------------------------------------------------------|
+| `placement` | Symbol/String | `:bottom`  | Preferred position: `:top`, `:bottom`, `:left`, `:right`.            |
+| `**options` | Hash          | `{}`       | HTML attributes on the wrapper `<div>`.                              |
+
+### `popover_trigger`
+
+| Parameter   | Type   | Default | Description                                                              |
+|-------------|--------|---------|--------------------------------------------------------------------------|
+| `as`        | Symbol | `nil`   | Render as another JetUi component (e.g. `:btn`). Options are forwarded.  |
+| `**options` | Hash   | `{}`    | HTML attributes on the trigger element.                                  |
+
+### `popover_content`
+
+| Parameter   | Type   | Default | Description                                        |
+|-------------|--------|---------|----------------------------------------------------|
+| `title`     | String | `nil`   | Optional title shown above the body content.       |
+| `**options` | Hash   | `{}`    | HTML attributes on the popover content `<div>`.    |
+
+## CSS classes
+
+| Class            | Description                       |
+|------------------|-----------------------------------|
+| `.popover`       | Floating content panel            |
+| `.popover__title`| Panel title                       |
+| `.popover__body` | Panel body                        |

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -1,0 +1,77 @@
+# Sidebar
+
+Vertical navigation component for application layouts. Pairs with the `sidebar` Stimulus controller to support open/close toggling via a trigger button elsewhere on the page.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Full sidebar example %>
+<div data-controller="sidebar">
+  <%= jet_ui.sidebar do %>
+    <%= jet_ui.sidebar_section do %>
+      <%= jet_ui.sidebar_title { "Main" } %>
+      <%= jet_ui.sidebar_menu do %>
+        <%= jet_ui.sidebar_link(url: root_path) { "Dashboard" } %>
+        <%= jet_ui.sidebar_link(url: users_path) { "Users" } %>
+        <%= jet_ui.sidebar_link(url: settings_path, disabled: true) { "Settings" } %>
+      <% end %>
+    <% end %>
+
+    <%= jet_ui.sidebar_section do %>
+      <%= jet_ui.sidebar_title { "Account" } %>
+      <%= jet_ui.sidebar_menu do %>
+        <%= jet_ui.sidebar_link(url: profile_path) { "Profile" } %>
+        <%= jet_ui.sidebar_link(url: sign_out_path, active: false) { "Sign out" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>
+
+<%# Toggle button (can live anywhere inside the sidebar controller element) %>
+<button data-action="click->sidebar#toggle">Menu</button>
+```
+
+## Parameters
+
+### `sidebar`
+
+| Parameter   | Type | Default | Description                                     |
+|-------------|------|---------|-------------------------------------------------|
+| `**options` | Hash | `{}`    | HTML attributes on the `<nav>` element.         |
+
+Always renders `data-sidebar-target="menu"` automatically.
+
+### `sidebar_section`
+
+Wraps a group of menu items. Accepts `**options` (HTML attributes on the wrapper `<div>`).
+
+### `sidebar_title`
+
+Section heading. Accepts `**options` (HTML attributes on the `<h4>` element).
+
+### `sidebar_menu`
+
+Unordered list container for links. Accepts `**options` (HTML attributes on the `<ul>` element).
+
+### `sidebar_link`
+
+| Parameter   | Type    | Default | Description                                                                            |
+|-------------|---------|---------|----------------------------------------------------------------------------------------|
+| `url`       | String  | `nil`   | Link destination.                                                                      |
+| `disabled`  | Boolean | `false` | Renders as a `<span>` instead of a link. Adds `.sidebar__link-disabled` style.         |
+| `active`    | Boolean | `nil`   | Forces active state. When `nil`, auto-detects via `current_page?`.                     |
+| `**options` | Hash    | `{}`    | HTML attributes on the `<a>` element (ignored when disabled).                          |
+
+## CSS classes
+
+| Class                    | Description                               |
+|--------------------------|-------------------------------------------|
+| `.sidebar`               | Root `<nav>` element                      |
+| `.sidebar__section`      | Section wrapper                           |
+| `.sidebar__title`        | Section heading                           |
+| `.sidebar__menu`         | `<ul>` list container                     |
+| `.sidebar__link`         | Individual navigation link                |
+| `.sidebar__link-active`  | Active state for the current page         |
+| `.sidebar__link-disabled`| Disabled (non-interactive) link           |

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -1,0 +1,42 @@
+# Tooltip
+
+Hover tooltip powered by Stimulus. Tooltip content is rendered in a dynamically created DOM element and positioned relative to its trigger. Position flips automatically when near viewport edges.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Examples
+
+```erb
+<%# Basic — wraps content in a <span> %>
+<%= jet_ui.tooltip(title: "More information") do %>
+  <%= jet_ui.icon("information-circle") %>
+<% end %>
+
+<%# Custom placement %>
+<%= jet_ui.tooltip(title: "Saved!", placement: :bottom) do %>
+  <%= jet_ui.btn("Save", variant: :outline) %>
+<% end %>
+
+<%# Render as another JetUi component %>
+<%= jet_ui.tooltip(title: "Delete permanently", as: :btn, variant: :danger) do %>
+  Delete
+<% end %>
+```
+
+## Parameters
+
+| Parameter   | Type           | Default | Description                                                              |
+|-------------|----------------|---------|--------------------------------------------------------------------------|
+| `title`     | String         | —       | Tooltip text content (required).                                         |
+| `as`        | Symbol         | `nil`   | Render as another JetUi component (e.g. `:btn`). Options are forwarded.  |
+| `placement` | Symbol/String  | `:top`  | Preferred position: `:top`, `:bottom`, `:left`, `:right`.                |
+| `**options` | Hash           | `{}`    | HTML attributes on the wrapper element.                                  |
+
+## Stimulus controller
+
+The `tooltip` Stimulus controller creates a tooltip element on `mouseenter` and removes it on `mouseleave`. It accepts the following values via `data-*` attributes (set automatically by the component):
+
+| Value     | Description                        |
+|-----------|------------------------------------|
+| `content` | The tooltip text to display.       |
+| `placement`| Preferred position for the tooltip.|

--- a/docs/components/turbo_confirm.md
+++ b/docs/components/turbo_confirm.md
@@ -1,0 +1,51 @@
+# Turbo Confirm
+
+Custom confirmation dialog for Turbo-powered destructive actions. Replaces the browser's default `confirm()` prompt with a styled modal dialog. Integrates with Turbo's `data-turbo-confirm` attribute on links and forms.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
+
+## Setup
+
+Add the component once to your application layout (e.g. `app/views/layouts/application.html.erb`):
+
+```erb
+<%= jet_ui.turbo_confirm %>
+```
+
+That's it. Any link or form with `data-turbo-confirm` will now use the modal dialog instead of `window.confirm`.
+
+## Usage in views
+
+```erb
+<%# Link with confirmation %>
+<%= link_to "Delete account", user_path(@user),
+      method: :delete,
+      data: { turbo_confirm: true } %>
+
+<%# Button/form %>
+<%= button_to "Remove", membership_path(@membership),
+      method: :delete,
+      data: { turbo_confirm: true } %>
+```
+
+The dialog shows "Are you absolutely sure?" with a "Cancel" and "Yes, I'm sure" button. Clicking "Yes, I'm sure" proceeds with the action; clicking "Cancel" or pressing Escape cancels it.
+
+## Customisation
+
+The default dialog text is intentionally generic. To customise the copy, eject the component:
+
+```bash
+rails generate jet_ui:eject turbo_confirm
+```
+
+Then edit `app/components/jet_ui/turbo_confirm/component.html.erb` in your application.
+
+## Stimulus controller
+
+The `turbo-confirm` Stimulus controller registers itself as Turbo's confirmation handler in `connect()`:
+
+```js
+Turbo.config.forms.confirm = (message, element) => { ... }
+```
+
+The controller ID `turbo-confirm` is derived from `turbo_confirm_controller.js` by `eagerLoadControllersFrom("jet_ui", application)`.

--- a/lib/generators/jet_ui/eject/eject_generator.rb
+++ b/lib/generators/jet_ui/eject/eject_generator.rb
@@ -14,12 +14,12 @@ module JetUi
         so they can be customised locally. Ejected files take precedence over
         the gem's built-in versions automatically — no extra configuration needed.
 
-        Available components: #{%w[btn card icon spinner avatar breadcrumbs tabs empty list divider timeline stepper table pagy flash].join(', ')}
+        Available components: #{%w[accordion btn card clipboard divider drawer dropdown empty flash header icon list modal navbar pagy popover sidebar spinner stat stepper table tabs timeline tooltip turbo_confirm].join(', ')}
 
         Examples:
           rails generate jet_ui:eject btn
           rails generate jet_ui:eject flash
-          rails generate jet_ui:eject btn card flash
+          rails generate jet_ui:eject modal drawer
           rails generate jet_ui:eject btn --skip-test
           rails generate jet_ui:eject btn --skip-preview
           rails generate jet_ui:eject flash --skip-javascript
@@ -212,6 +212,128 @@ module JetUi
             { src: 'test/components/previews/jet_ui/list/component_preview.rb',                                 dest: 'test/components/previews/jet_ui/list/component_preview.rb',              type: :preview },
             { src: 'test/components/previews/jet_ui/list/component_preview/default.html.erb',                   dest: 'test/components/previews/jet_ui/list/component_preview/default.html.erb', type: :preview },
             { src: 'test/components/previews/jet_ui/list/component_preview/divided.html.erb',                   dest: 'test/components/previews/jet_ui/list/component_preview/divided.html.erb', type: :preview }
+          ]
+        },
+        'accordion' => {
+          files: [
+            { src: 'app/components/jet_ui/accordion/component.rb',                                              dest: 'app/components/jet_ui/accordion/component.rb' },
+            { src: 'app/components/jet_ui/accordion/summary_component.rb',                                      dest: 'app/components/jet_ui/accordion/summary_component.rb' },
+            { src: 'app/components/jet_ui/accordion/body_component.rb',                                         dest: 'app/components/jet_ui/accordion/body_component.rb' },
+            { src: 'test/components/jet_ui/accordion/component_test.rb',                                        dest: 'test/components/jet_ui/accordion/component_test.rb',                     type: :test },
+            { src: 'test/components/previews/jet_ui/accordion/component_preview.rb',                            dest: 'test/components/previews/jet_ui/accordion/component_preview.rb',         type: :preview }
+          ]
+        },
+        'clipboard' => {
+          files: [
+            { src: 'app/components/jet_ui/clipboard/component.rb',                                              dest: 'app/components/jet_ui/clipboard/component.rb' },
+            { src: 'app/assets/javascripts/jet_ui/clipboard_controller.js',                                     dest: 'app/assets/javascripts/jet_ui/clipboard_controller.js',                  type: :javascript },
+            { src: 'test/components/jet_ui/clipboard/component_test.rb',                                        dest: 'test/components/jet_ui/clipboard/component_test.rb',                     type: :test },
+            { src: 'test/components/previews/jet_ui/clipboard/component_preview.rb',                            dest: 'test/components/previews/jet_ui/clipboard/component_preview.rb',         type: :preview }
+          ]
+        },
+        'sidebar' => {
+          files: [
+            { src: 'app/components/jet_ui/sidebar/component.rb',                                                dest: 'app/components/jet_ui/sidebar/component.rb' },
+            { src: 'app/components/jet_ui/sidebar/link_component.rb',                                           dest: 'app/components/jet_ui/sidebar/link_component.rb' },
+            { src: 'app/components/jet_ui/sidebar/menu_component.rb',                                           dest: 'app/components/jet_ui/sidebar/menu_component.rb' },
+            { src: 'app/components/jet_ui/sidebar/section_component.rb',                                        dest: 'app/components/jet_ui/sidebar/section_component.rb' },
+            { src: 'app/components/jet_ui/sidebar/title_component.rb',                                          dest: 'app/components/jet_ui/sidebar/title_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/sidebar.css',                                                 dest: 'app/assets/stylesheets/jet_ui/sidebar.css' },
+            { src: 'test/components/jet_ui/sidebar/component_test.rb',                                          dest: 'test/components/jet_ui/sidebar/component_test.rb',                      type: :test },
+            { src: 'test/components/previews/jet_ui/sidebar/component_preview.rb',                              dest: 'test/components/previews/jet_ui/sidebar/component_preview.rb',          type: :preview }
+          ]
+        },
+        'header' => {
+          files: [
+            { src: 'app/components/jet_ui/header/component.rb',                                                 dest: 'app/components/jet_ui/header/component.rb' },
+            { src: 'app/components/jet_ui/header/heading_component.rb',                                         dest: 'app/components/jet_ui/header/heading_component.rb' },
+            { src: 'app/components/jet_ui/header/title_component.rb',                                           dest: 'app/components/jet_ui/header/title_component.rb' },
+            { src: 'app/components/jet_ui/header/subtitle_component.rb',                                        dest: 'app/components/jet_ui/header/subtitle_component.rb' },
+            { src: 'app/components/jet_ui/header/actions_component.rb',                                         dest: 'app/components/jet_ui/header/actions_component.rb' },
+            { src: 'test/components/jet_ui/header/component_test.rb',                                           dest: 'test/components/jet_ui/header/component_test.rb',                       type: :test },
+            { src: 'test/components/previews/jet_ui/header/component_preview.rb',                               dest: 'test/components/previews/jet_ui/header/component_preview.rb',           type: :preview }
+          ]
+        },
+        'navbar' => {
+          files: [
+            { src: 'app/components/jet_ui/navbar/component.rb',                                                 dest: 'app/components/jet_ui/navbar/component.rb' },
+            { src: 'app/components/jet_ui/navbar/brand_component.rb',                                           dest: 'app/components/jet_ui/navbar/brand_component.rb' },
+            { src: 'app/components/jet_ui/navbar/content_component.rb',                                         dest: 'app/components/jet_ui/navbar/content_component.rb' },
+            { src: 'app/components/jet_ui/navbar/main_component.rb',                                            dest: 'app/components/jet_ui/navbar/main_component.rb' },
+            { src: 'app/components/jet_ui/navbar/actions_component.rb',                                         dest: 'app/components/jet_ui/navbar/actions_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/navbar.css',                                                  dest: 'app/assets/stylesheets/jet_ui/navbar.css' },
+            { src: 'test/components/jet_ui/navbar/component_test.rb',                                           dest: 'test/components/jet_ui/navbar/component_test.rb',                       type: :test },
+            { src: 'test/components/previews/jet_ui/navbar/component_preview.rb',                               dest: 'test/components/previews/jet_ui/navbar/component_preview.rb',           type: :preview }
+          ]
+        },
+        'modal' => {
+          files: [
+            { src: 'app/components/jet_ui/modal/component.rb',                                                  dest: 'app/components/jet_ui/modal/component.rb' },
+            { src: 'app/components/jet_ui/modal/header_component.rb',                                           dest: 'app/components/jet_ui/modal/header_component.rb' },
+            { src: 'app/components/jet_ui/modal/body_component.rb',                                             dest: 'app/components/jet_ui/modal/body_component.rb' },
+            { src: 'app/components/jet_ui/modal/footer_component.rb',                                           dest: 'app/components/jet_ui/modal/footer_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/modal.css',                                                   dest: 'app/assets/stylesheets/jet_ui/modal.css' },
+            { src: 'app/assets/javascripts/jet_ui/modal_controller.js',                                         dest: 'app/assets/javascripts/jet_ui/modal_controller.js',                     type: :javascript },
+            { src: 'app/assets/javascripts/jet_ui/modals_controller.js',                                        dest: 'app/assets/javascripts/jet_ui/modals_controller.js',                    type: :javascript },
+            { src: 'test/components/jet_ui/modal/component_test.rb',                                            dest: 'test/components/jet_ui/modal/component_test.rb',                        type: :test },
+            { src: 'test/components/previews/jet_ui/modal/component_preview.rb',                                dest: 'test/components/previews/jet_ui/modal/component_preview.rb',            type: :preview }
+          ]
+        },
+        'drawer' => {
+          files: [
+            { src: 'app/components/jet_ui/drawer/component.rb',                                                 dest: 'app/components/jet_ui/drawer/component.rb' },
+            { src: 'app/components/jet_ui/drawer/header_component.rb',                                          dest: 'app/components/jet_ui/drawer/header_component.rb' },
+            { src: 'app/components/jet_ui/drawer/body_component.rb',                                            dest: 'app/components/jet_ui/drawer/body_component.rb' },
+            { src: 'app/components/jet_ui/drawer/footer_component.rb',                                          dest: 'app/components/jet_ui/drawer/footer_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/drawer.css',                                                  dest: 'app/assets/stylesheets/jet_ui/drawer.css' },
+            { src: 'app/assets/javascripts/jet_ui/drawer_controller.js',                                        dest: 'app/assets/javascripts/jet_ui/drawer_controller.js',                    type: :javascript },
+            { src: 'app/assets/javascripts/jet_ui/drawers_controller.js',                                       dest: 'app/assets/javascripts/jet_ui/drawers_controller.js',                   type: :javascript },
+            { src: 'test/components/jet_ui/drawer/component_test.rb',                                           dest: 'test/components/jet_ui/drawer/component_test.rb',                       type: :test },
+            { src: 'test/components/previews/jet_ui/drawer/component_preview.rb',                               dest: 'test/components/previews/jet_ui/drawer/component_preview.rb',           type: :preview }
+          ]
+        },
+        'dropdown' => {
+          files: [
+            { src: 'app/components/jet_ui/dropdown/component.rb',                                               dest: 'app/components/jet_ui/dropdown/component.rb' },
+            { src: 'app/components/jet_ui/dropdown/trigger_component.rb',                                       dest: 'app/components/jet_ui/dropdown/trigger_component.rb' },
+            { src: 'app/components/jet_ui/dropdown/menu_component.rb',                                          dest: 'app/components/jet_ui/dropdown/menu_component.rb' },
+            { src: 'app/components/jet_ui/dropdown/link_component.rb',                                          dest: 'app/components/jet_ui/dropdown/link_component.rb' },
+            { src: 'app/components/jet_ui/dropdown/button_component.rb',                                        dest: 'app/components/jet_ui/dropdown/button_component.rb' },
+            { src: 'app/components/jet_ui/dropdown/title_component.rb',                                         dest: 'app/components/jet_ui/dropdown/title_component.rb' },
+            { src: 'app/components/jet_ui/dropdown/divider_component.rb',                                       dest: 'app/components/jet_ui/dropdown/divider_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/dropdown.css',                                                dest: 'app/assets/stylesheets/jet_ui/dropdown.css' },
+            { src: 'app/assets/javascripts/jet_ui/dropdown_controller.js',                                      dest: 'app/assets/javascripts/jet_ui/dropdown_controller.js',                  type: :javascript },
+            { src: 'test/components/jet_ui/dropdown/component_test.rb',                                         dest: 'test/components/jet_ui/dropdown/component_test.rb',                     type: :test },
+            { src: 'test/components/previews/jet_ui/dropdown/component_preview.rb',                             dest: 'test/components/previews/jet_ui/dropdown/component_preview.rb',         type: :preview }
+          ]
+        },
+        'tooltip' => {
+          files: [
+            { src: 'app/components/jet_ui/tooltip/component.rb',                                                dest: 'app/components/jet_ui/tooltip/component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/tooltip.css',                                                 dest: 'app/assets/stylesheets/jet_ui/tooltip.css' },
+            { src: 'app/assets/javascripts/jet_ui/tooltip_controller.js',                                       dest: 'app/assets/javascripts/jet_ui/tooltip_controller.js',                   type: :javascript },
+            { src: 'test/components/jet_ui/tooltip/component_test.rb',                                          dest: 'test/components/jet_ui/tooltip/component_test.rb',                      type: :test },
+            { src: 'test/components/previews/jet_ui/tooltip/component_preview.rb',                              dest: 'test/components/previews/jet_ui/tooltip/component_preview.rb',          type: :preview }
+          ]
+        },
+        'popover' => {
+          files: [
+            { src: 'app/components/jet_ui/popover/component.rb',                                                dest: 'app/components/jet_ui/popover/component.rb' },
+            { src: 'app/components/jet_ui/popover/trigger_component.rb',                                        dest: 'app/components/jet_ui/popover/trigger_component.rb' },
+            { src: 'app/components/jet_ui/popover/content_component.rb',                                        dest: 'app/components/jet_ui/popover/content_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/popover.css',                                                 dest: 'app/assets/stylesheets/jet_ui/popover.css' },
+            { src: 'app/assets/javascripts/jet_ui/popover_controller.js',                                       dest: 'app/assets/javascripts/jet_ui/popover_controller.js',                   type: :javascript },
+            { src: 'test/components/jet_ui/popover/component_test.rb',                                          dest: 'test/components/jet_ui/popover/component_test.rb',                      type: :test },
+            { src: 'test/components/previews/jet_ui/popover/component_preview.rb',                              dest: 'test/components/previews/jet_ui/popover/component_preview.rb',          type: :preview }
+          ]
+        },
+        'turbo_confirm' => {
+          files: [
+            { src: 'app/components/jet_ui/turbo_confirm/component.rb',                                          dest: 'app/components/jet_ui/turbo_confirm/component.rb' },
+            { src: 'app/components/jet_ui/turbo_confirm/component.html.erb',                                    dest: 'app/components/jet_ui/turbo_confirm/component.html.erb' },
+            { src: 'app/assets/javascripts/jet_ui/turbo_confirm_controller.js', dest: 'app/assets/javascripts/jet_ui/turbo_confirm_controller.js', type: :javascript },
+            { src: 'test/components/jet_ui/turbo_confirm/component_test.rb',                                    dest: 'test/components/jet_ui/turbo_confirm/component_test.rb',                type: :test },
+            { src: 'test/components/previews/jet_ui/turbo_confirm/component_preview.rb',                        dest: 'test/components/previews/jet_ui/turbo_confirm/component_preview.rb',    type: :preview }
           ]
         }
       }.freeze

--- a/test/components/jet_ui/accordion/component_test.rb
+++ b/test/components/jet_ui/accordion/component_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Accordion::ComponentTest < ViewComponent::TestCase
+  def test_renders_details_element
+    render_inline(JetUi::Accordion::Component.new) { 'content' }
+
+    assert_selector 'details.group'
+  end
+
+  def test_closed_by_default
+    render_inline(JetUi::Accordion::Component.new) { 'content' }
+
+    assert_no_selector 'details[open]'
+  end
+
+  def test_open_prop
+    render_inline(JetUi::Accordion::Component.new(open: true)) { 'content' }
+
+    assert_selector 'details[open]'
+  end
+
+  def test_name_attribute
+    render_inline(JetUi::Accordion::Component.new(name: 'faq')) { 'content' }
+
+    assert_selector 'details[name="faq"]'
+  end
+
+  def test_custom_class
+    render_inline(JetUi::Accordion::Component.new(class: 'my-class')) { 'content' }
+
+    assert_selector 'details.group.my-class'
+  end
+
+  def test_summary_renders_summary_tag
+    render_inline(JetUi::Accordion::SummaryComponent.new) { 'Question' }
+
+    assert_selector 'summary'
+    assert_text 'Question'
+  end
+
+  def test_summary_has_chevron_icon
+    render_inline(JetUi::Accordion::SummaryComponent.new) { 'Q' }
+
+    assert_selector 'summary svg, summary span'
+  end
+
+  def test_summary_no_icon_when_nil
+    render_inline(JetUi::Accordion::SummaryComponent.new(icon: nil)) { 'Q' }
+
+    assert_no_selector 'summary svg'
+  end
+
+  def test_body_renders_div
+    render_inline(JetUi::Accordion::BodyComponent.new) { 'Answer' }
+
+    assert_selector 'div'
+    assert_text 'Answer'
+  end
+end

--- a/test/components/jet_ui/clipboard/component_test.rb
+++ b/test/components/jet_ui/clipboard/component_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Clipboard::ComponentTest < ViewComponent::TestCase
+  def test_renders_span_by_default
+    render_inline(JetUi::Clipboard::Component.new(value: 'text')) { 'Copy' }
+
+    assert_selector 'span.cursor-pointer'
+    assert_text 'Copy'
+  end
+
+  def test_has_clipboard_controller
+    render_inline(JetUi::Clipboard::Component.new(value: 'text')) { 'Copy' }
+
+    assert_selector '[data-controller="clipboard"]'
+  end
+
+  def test_sets_content_value
+    render_inline(JetUi::Clipboard::Component.new(value: 'my text')) { 'Copy' }
+
+    assert_selector '[data-clipboard-content-value="my text"]'
+  end
+
+  def test_sets_source_id_value
+    render_inline(JetUi::Clipboard::Component.new(source_id: 'my_input')) { 'Copy' }
+
+    assert_selector '[data-clipboard-source-id-value="my_input"]'
+  end
+
+  def test_sets_success_text_value
+    render_inline(JetUi::Clipboard::Component.new(value: 'text', success_text: 'Done!')) { 'Copy' }
+
+    assert_selector '[data-clipboard-success-text-value="Done!"]'
+  end
+
+  def test_has_copy_action
+    render_inline(JetUi::Clipboard::Component.new(value: 'text')) { 'Copy' }
+
+    assert_selector '[data-action="click->clipboard#copy"]'
+  end
+
+  def test_adds_tooltip_controller_when_tooltip_given
+    render_inline(JetUi::Clipboard::Component.new(value: 'text', tooltip: 'Click to copy')) { 'Copy' }
+
+    assert_selector '[data-controller="clipboard tooltip"]'
+  end
+
+  def test_custom_class
+    render_inline(JetUi::Clipboard::Component.new(value: 'text', class: 'extra')) { 'Copy' }
+
+    assert_selector 'span.cursor-pointer.extra'
+  end
+end

--- a/test/components/jet_ui/drawer/component_test.rb
+++ b/test/components/jet_ui/drawer/component_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Drawer::ComponentTest < ViewComponent::TestCase
+  def test_renders_sync_dialog_with_id
+    render_inline(JetUi::Drawer::Component.new(id: 'my-drawer'))
+
+    assert_selector 'dialog#my-drawer'
+    assert_selector 'dialog[data-drawers-target="dialog"]'
+  end
+
+  def test_renders_div_without_id_outside_turbo_frame
+    render_inline(JetUi::Drawer::Component.new)
+
+    assert_selector 'div.bg-background'
+    assert_no_selector 'dialog'
+  end
+
+  def test_header_renders_title
+    render_inline(JetUi::Drawer::HeaderComponent.new(title: 'My Drawer'))
+
+    assert_selector 'h3.drawer__title'
+    assert_text 'My Drawer'
+  end
+
+  def test_header_renders_subtitle
+    render_inline(JetUi::Drawer::HeaderComponent.new(subtitle: 'Info'))
+
+    assert_selector 'div.drawer__subtitle'
+    assert_text 'Info'
+  end
+
+  def test_closable_header_has_close_button
+    render_inline(JetUi::Drawer::HeaderComponent.new(closable: true))
+
+    assert_selector 'button.drawer__close'
+  end
+
+  def test_non_closable_header_omits_close_button
+    render_inline(JetUi::Drawer::HeaderComponent.new(closable: false))
+
+    assert_no_selector 'button.drawer__close'
+  end
+
+  def test_body_renders_div
+    render_inline(JetUi::Drawer::BodyComponent.new) { 'Body' }
+
+    assert_selector 'div.drawer__body'
+    assert_text 'Body'
+  end
+
+  def test_footer_renders_div
+    render_inline(JetUi::Drawer::FooterComponent.new) { 'Footer' }
+
+    assert_selector 'div.drawer__footer'
+  end
+
+  def test_footer_bordered_by_default
+    render_inline(JetUi::Drawer::FooterComponent.new) { 'Footer' }
+
+    assert_selector 'div.drawer__footer-bordered'
+  end
+end

--- a/test/components/jet_ui/dropdown/component_test.rb
+++ b/test/components/jet_ui/dropdown/component_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Dropdown::ComponentTest < ViewComponent::TestCase
+  def test_renders_with_dropdown_class
+    render_inline(JetUi::Dropdown::Component.new) { 'content' }
+
+    assert_selector 'div.dropdown'
+  end
+
+  def test_has_stimulus_controller
+    render_inline(JetUi::Dropdown::Component.new) { 'content' }
+
+    assert_selector 'div[data-controller="dropdown"]'
+  end
+
+  def test_trigger_renders_span
+    render_inline(JetUi::Dropdown::TriggerComponent.new) { 'Open' }
+
+    assert_selector 'span[role="button"]'
+    assert_text 'Open'
+  end
+
+  def test_trigger_has_dropdown_target
+    render_inline(JetUi::Dropdown::TriggerComponent.new) { 'Open' }
+
+    assert_selector '[data-dropdown-target="trigger"]'
+  end
+
+  def test_menu_renders_wrapper
+    render_inline(JetUi::Dropdown::MenuComponent.new) { 'items' }
+
+    assert_selector 'div.dropdown__menu'
+    assert_selector 'div[data-dropdown-target="menu"]'
+  end
+
+  def test_link_renders_li_with_anchor
+    render_inline(JetUi::Dropdown::LinkComponent.new(url: '/path')) { 'Link' }
+
+    assert_selector 'li.dropdown__item a.dropdown__link'
+    assert_text 'Link'
+  end
+
+  def test_active_link_has_active_class
+    render_inline(JetUi::Dropdown::LinkComponent.new(url: '/path', active: true)) { 'Link' }
+
+    assert_selector 'a.dropdown__link-active'
+  end
+
+  def test_title_renders_h6
+    render_inline(JetUi::Dropdown::TitleComponent.new) { 'Title' }
+
+    assert_selector 'h6.dropdown__title'
+    assert_text 'Title'
+  end
+
+  def test_divider_renders_li
+    render_inline(JetUi::Dropdown::DividerComponent.new)
+
+    assert_selector 'li.dropdown__divider'
+  end
+
+  def test_custom_class
+    render_inline(JetUi::Dropdown::Component.new(class: 'extra')) { 'content' }
+
+    assert_selector 'div.dropdown.extra'
+  end
+end

--- a/test/components/jet_ui/header/component_test.rb
+++ b/test/components/jet_ui/header/component_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Header::ComponentTest < ViewComponent::TestCase
+  def test_renders_div
+    render_inline(JetUi::Header::Component.new) { 'content' }
+
+    assert_selector 'div'
+    assert_text 'content'
+  end
+
+  def test_default_justify_between
+    render_inline(JetUi::Header::Component.new) { 'content' }
+
+    assert_selector 'div.header--justify-between'
+  end
+
+  def test_sticky_adds_classes
+    render_inline(JetUi::Header::Component.new(sticky: true)) { 'content' }
+
+    assert_selector 'div.header--sticky'
+  end
+
+  def test_bordered_adds_class
+    render_inline(JetUi::Header::Component.new(bordered: true)) { 'content' }
+
+    assert_selector 'div.header--bordered'
+  end
+
+  def test_heading_renders_div
+    render_inline(JetUi::Header::HeadingComponent.new) { 'content' }
+
+    assert_selector 'div.header__heading'
+  end
+
+  def test_title_renders_h1
+    render_inline(JetUi::Header::TitleComponent.new) { 'Page Title' }
+
+    assert_selector 'h1'
+    assert_text 'Page Title'
+  end
+
+  def test_subtitle_renders_p
+    render_inline(JetUi::Header::SubtitleComponent.new) { 'Subtitle text' }
+
+    assert_selector 'p.header__subtitle'
+    assert_text 'Subtitle text'
+  end
+
+  def test_actions_renders_div
+    render_inline(JetUi::Header::ActionsComponent.new) { 'actions' }
+
+    assert_selector 'div.header__actions'
+  end
+end

--- a/test/components/jet_ui/modal/component_test.rb
+++ b/test/components/jet_ui/modal/component_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Modal::ComponentTest < ViewComponent::TestCase
+  def test_renders_sync_dialog_with_id
+    render_inline(JetUi::Modal::Component.new(id: 'my-modal'))
+
+    assert_selector 'dialog#my-modal'
+    assert_selector 'dialog[data-modals-target="dialog"]'
+  end
+
+  def test_renders_div_without_id_outside_turbo_frame
+    render_inline(JetUi::Modal::Component.new)
+
+    assert_selector 'div.modal'
+    assert_no_selector 'dialog'
+  end
+
+  def test_header_renders_title
+    render_inline(JetUi::Modal::HeaderComponent.new(title: 'My Modal'))
+
+    assert_selector 'h3.modal__title'
+    assert_text 'My Modal'
+  end
+
+  def test_header_renders_subtitle
+    render_inline(JetUi::Modal::HeaderComponent.new(subtitle: 'Subtitle'))
+
+    assert_selector 'div.modal__subtitle'
+    assert_text 'Subtitle'
+  end
+
+  def test_closable_header_has_close_button
+    render_inline(JetUi::Modal::HeaderComponent.new(closable: true))
+
+    assert_selector 'button.modal__close'
+  end
+
+  def test_non_closable_header_has_no_close_button
+    render_inline(JetUi::Modal::HeaderComponent.new(closable: false))
+
+    assert_no_selector 'button.modal__close'
+  end
+
+  def test_header_bordered_by_default
+    render_inline(JetUi::Modal::HeaderComponent.new)
+
+    assert_selector 'div.modal__header-bordered'
+  end
+
+  def test_body_renders_div
+    render_inline(JetUi::Modal::BodyComponent.new) { 'Body content' }
+
+    assert_selector 'div.modal__body'
+    assert_text 'Body content'
+  end
+
+  def test_footer_renders_div
+    render_inline(JetUi::Modal::FooterComponent.new) { 'Footer' }
+
+    assert_selector 'div.modal__footer'
+  end
+
+  def test_footer_bordered_by_default
+    render_inline(JetUi::Modal::FooterComponent.new) { 'Footer' }
+
+    assert_selector 'div.modal__footer-bordered'
+  end
+
+  def test_footer_justify_end
+    render_inline(JetUi::Modal::FooterComponent.new(justify: :end)) { 'Footer' }
+
+    assert_selector 'div.justify-end'
+  end
+end

--- a/test/components/jet_ui/navbar/component_test.rb
+++ b/test/components/jet_ui/navbar/component_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Navbar::ComponentTest < ViewComponent::TestCase
+  def test_renders_header
+    render_inline(JetUi::Navbar::Component.new) { 'content' }
+
+    assert_selector 'header.navbar'
+  end
+
+  def test_sticky_by_default
+    render_inline(JetUi::Navbar::Component.new) { 'content' }
+
+    assert_selector 'header.navbar-sticky'
+  end
+
+  def test_non_sticky
+    render_inline(JetUi::Navbar::Component.new(sticky: false)) { 'content' }
+
+    assert_no_selector 'header.navbar-sticky'
+  end
+
+  def test_brand_renders_div
+    render_inline(JetUi::Navbar::BrandComponent.new) { 'Logo' }
+
+    assert_selector 'div.navbar__brand'
+    assert_text 'Logo'
+  end
+
+  def test_content_renders_div
+    render_inline(JetUi::Navbar::ContentComponent.new) { 'content' }
+
+    assert_selector 'div.navbar__content'
+  end
+
+  def test_main_renders_div
+    render_inline(JetUi::Navbar::MainComponent.new) { 'main' }
+
+    assert_selector 'div.navbar__main'
+  end
+
+  def test_actions_renders_div
+    render_inline(JetUi::Navbar::ActionsComponent.new) { 'actions' }
+
+    assert_selector 'div.navbar__actions'
+  end
+
+  def test_custom_class
+    render_inline(JetUi::Navbar::Component.new(class: 'border-b')) { 'content' }
+
+    assert_selector 'header.navbar.border-b'
+  end
+end

--- a/test/components/jet_ui/popover/component_test.rb
+++ b/test/components/jet_ui/popover/component_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Popover::ComponentTest < ViewComponent::TestCase
+  def test_renders_wrapper_div
+    render_inline(JetUi::Popover::Component.new) { 'content' }
+
+    assert_selector 'div.w-fit'
+  end
+
+  def test_has_popover_controller
+    render_inline(JetUi::Popover::Component.new) { 'content' }
+
+    assert_selector '[data-controller="popover"]'
+  end
+
+  def test_default_placement_bottom
+    render_inline(JetUi::Popover::Component.new) { 'content' }
+
+    assert_selector '[data-popover-placement-value="bottom"]'
+  end
+
+  def test_custom_placement
+    render_inline(JetUi::Popover::Component.new(placement: :right)) { 'content' }
+
+    assert_selector '[data-popover-placement-value="right"]'
+  end
+
+  def test_trigger_renders_span
+    render_inline(JetUi::Popover::TriggerComponent.new) { 'Open' }
+
+    assert_selector 'span'
+    assert_text 'Open'
+  end
+
+  def test_content_renders_popover_div
+    render_inline(JetUi::Popover::ContentComponent.new) { 'Popover body' }
+
+    assert_selector 'div.popover'
+    assert_selector 'div[data-popover-target="content"]'
+    assert_text 'Popover body'
+  end
+
+  def test_content_with_title
+    render_inline(JetUi::Popover::ContentComponent.new(title: 'My Title')) { 'Body' }
+
+    assert_selector 'div.popover__title'
+    assert_text 'My Title'
+  end
+
+  def test_content_without_title
+    render_inline(JetUi::Popover::ContentComponent.new) { 'Body' }
+
+    assert_no_selector 'div.popover__title'
+  end
+end

--- a/test/components/jet_ui/sidebar/component_test.rb
+++ b/test/components/jet_ui/sidebar/component_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Sidebar::ComponentTest < ViewComponent::TestCase
+  def test_renders_nav
+    render_inline(JetUi::Sidebar::Component.new) { 'content' }
+
+    assert_selector 'nav.sidebar'
+  end
+
+  def test_has_sidebar_target
+    render_inline(JetUi::Sidebar::Component.new) { 'content' }
+
+    assert_selector 'nav[data-sidebar-target="menu"]'
+  end
+
+  def test_custom_class
+    render_inline(JetUi::Sidebar::Component.new(class: 'extra')) { 'content' }
+
+    assert_selector 'nav.sidebar.extra'
+  end
+
+  def test_section_renders_div
+    render_inline(JetUi::Sidebar::SectionComponent.new) { 'content' }
+
+    assert_selector 'div.sidebar__section'
+  end
+
+  def test_title_renders_h4
+    render_inline(JetUi::Sidebar::TitleComponent.new) { 'Navigation' }
+
+    assert_selector 'h4.sidebar__title'
+    assert_text 'Navigation'
+  end
+
+  def test_menu_renders_ul
+    render_inline(JetUi::Sidebar::MenuComponent.new) { 'content' }
+
+    assert_selector 'ul.sidebar__menu'
+  end
+
+  def test_link_renders_li_with_link
+    render_inline(JetUi::Sidebar::LinkComponent.new(url: '/home')) { 'Home' }
+
+    assert_selector 'li a.sidebar__link[href="/home"]'
+    assert_text 'Home'
+  end
+
+  def test_disabled_link_renders_span
+    render_inline(JetUi::Sidebar::LinkComponent.new(disabled: true)) { 'Coming Soon' }
+
+    assert_selector 'li span.sidebar__link-disabled'
+    assert_no_selector 'li a'
+  end
+
+  def test_active_link_has_active_class
+    render_inline(JetUi::Sidebar::LinkComponent.new(url: '/home', active: true)) { 'Home' }
+
+    assert_selector 'a.sidebar__link-active'
+  end
+end

--- a/test/components/jet_ui/tooltip/component_test.rb
+++ b/test/components/jet_ui/tooltip/component_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Tooltip::ComponentTest < ViewComponent::TestCase
+  def test_renders_span_by_default
+    render_inline(JetUi::Tooltip::Component.new(title: 'Tooltip text')) { 'Hover me' }
+
+    assert_selector 'span.w-fit'
+    assert_text 'Hover me'
+  end
+
+  def test_has_tooltip_controller
+    render_inline(JetUi::Tooltip::Component.new(title: 'Tooltip text')) { 'Hover me' }
+
+    assert_selector '[data-controller="tooltip"]'
+  end
+
+  def test_sets_content_value
+    render_inline(JetUi::Tooltip::Component.new(title: 'My tip')) { 'Hover me' }
+
+    assert_selector '[data-tooltip-content-value="My tip"]'
+  end
+
+  def test_default_placement_top
+    render_inline(JetUi::Tooltip::Component.new(title: 'tip')) { 'Hover' }
+
+    assert_selector '[data-tooltip-placement-value="top"]'
+  end
+
+  def test_custom_placement
+    render_inline(JetUi::Tooltip::Component.new(title: 'tip', placement: :right)) { 'Hover' }
+
+    assert_selector '[data-tooltip-placement-value="right"]'
+  end
+end

--- a/test/components/jet_ui/turbo_confirm/component_test.rb
+++ b/test/components/jet_ui/turbo_confirm/component_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::TurboConfirm::ComponentTest < ViewComponent::TestCase
+  def test_renders_dialog
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'dialog#turbo-confirm'
+  end
+
+  def test_has_turbo_confirm_controller
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'dialog[data-controller="turbo-confirm"]'
+  end
+
+  def test_has_form_with_dialog_method
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'form[method="dialog"]'
+  end
+
+  def test_has_cancel_button
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'button[value="cancel"]'
+    assert_text 'Cancel'
+  end
+
+  def test_has_confirm_button
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'button[value="confirm"]'
+  end
+
+  def test_has_modal_classes
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'dialog.modal'
+  end
+end

--- a/test/components/previews/jet_ui/accordion/component_preview.rb
+++ b/test/components/previews/jet_ui/accordion/component_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class JetUi::Accordion::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::Accordion::Component.new(name: 'faq', open: true) do
+      render(JetUi::Accordion::SummaryComponent.new) { 'What is this?' }
+      render(JetUi::Accordion::BodyComponent.new) { 'An accordion component.' }
+    end
+  end
+
+  def group
+    render_with_template
+  end
+end

--- a/test/components/previews/jet_ui/clipboard/component_preview.rb
+++ b/test/components/previews/jet_ui/clipboard/component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class JetUi::Clipboard::ComponentPreview < ViewComponent::Preview
+  def copy_value
+    render JetUi::Clipboard::Component.new(value: 'Text to copy') { 'Copy' }
+  end
+
+  def with_success_text
+    render JetUi::Clipboard::Component.new(value: 'https://example.com', success_text: 'URL copied!') { 'Copy URL' }
+  end
+end

--- a/test/components/previews/jet_ui/drawer/component_preview.rb
+++ b/test/components/previews/jet_ui/drawer/component_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class JetUi::Drawer::ComponentPreview < ViewComponent::Preview
+  def sync_drawer
+    render JetUi::Drawer::Component.new(title: 'Drawer Title', id: 'preview-drawer') do
+      render(JetUi::Drawer::BodyComponent.new) { 'Drawer content goes here.' }
+      render(JetUi::Drawer::FooterComponent.new) do
+        render(JetUi::Btn::Component.new(variant: :secondary)) { 'Close' }
+      end
+    end
+  end
+
+  def header_only
+    render JetUi::Drawer::HeaderComponent.new(title: 'Drawer Title', subtitle: 'Subtitle', closable: false)
+  end
+
+  def body
+    render JetUi::Drawer::BodyComponent.new do
+      'Drawer body content'
+    end
+  end
+end

--- a/test/components/previews/jet_ui/dropdown/component_preview.rb
+++ b/test/components/previews/jet_ui/dropdown/component_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class JetUi::Dropdown::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::Dropdown::Component.new do
+      render(JetUi::Dropdown::TriggerComponent.new) { 'Open Menu' }
+      render(JetUi::Dropdown::MenuComponent.new) do
+        render(JetUi::Dropdown::LinkComponent.new(url: '#')) { 'Profile' }
+        render(JetUi::Dropdown::LinkComponent.new(url: '#')) { 'Settings' }
+        render(JetUi::Dropdown::DividerComponent.new)
+        render(JetUi::Dropdown::LinkComponent.new(url: '#')) { 'Sign Out' }
+      end
+    end
+  end
+
+  def with_title
+    render JetUi::Dropdown::Component.new do
+      render(JetUi::Dropdown::TriggerComponent.new) { 'Menu' }
+      render(JetUi::Dropdown::MenuComponent.new) do
+        render(JetUi::Dropdown::TitleComponent.new) { 'Account' }
+        render(JetUi::Dropdown::LinkComponent.new(url: '#')) { 'Profile' }
+        render(JetUi::Dropdown::LinkComponent.new(url: '#', active: true)) { 'Dashboard' }
+      end
+    end
+  end
+end

--- a/test/components/previews/jet_ui/header/component_preview.rb
+++ b/test/components/previews/jet_ui/header/component_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class JetUi::Header::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::Header::Component.new do
+      render(JetUi::Header::HeadingComponent.new) do
+        render(JetUi::Header::TitleComponent.new) { 'Page Title' }
+        render(JetUi::Header::SubtitleComponent.new) { 'A brief description.' }
+      end
+      render(JetUi::Header::ActionsComponent.new) do
+        render(JetUi::Btn::Component.new) { 'Action' }
+      end
+    end
+  end
+
+  def bordered
+    render JetUi::Header::Component.new(bordered: true) do
+      render(JetUi::Header::HeadingComponent.new) do
+        render(JetUi::Header::TitleComponent.new) { 'Bordered Header' }
+      end
+    end
+  end
+end

--- a/test/components/previews/jet_ui/modal/component_preview.rb
+++ b/test/components/previews/jet_ui/modal/component_preview.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class JetUi::Modal::ComponentPreview < ViewComponent::Preview
+  def sync_modal
+    render JetUi::Modal::Component.new(title: 'Modal Title', subtitle: 'Subtitle', id: 'preview-modal') do
+      render(JetUi::Modal::BodyComponent.new) { 'Modal content goes here.' }
+      render(JetUi::Modal::FooterComponent.new, justify: :end) do
+        render(JetUi::Btn::Component.new(variant: :secondary)) { 'Cancel' }
+        render(JetUi::Btn::Component.new) { 'Confirm' }
+      end
+    end
+  end
+
+  def header_only
+    render JetUi::Modal::HeaderComponent.new(title: 'Header Title', subtitle: 'Header subtitle')
+  end
+
+  def body
+    render JetUi::Modal::BodyComponent.new do
+      'Body content'
+    end
+  end
+
+  def footer_end
+    render JetUi::Modal::FooterComponent.new(justify: :end) do
+      render(JetUi::Btn::Component.new(variant: :outline)) { 'Cancel' }
+      render(JetUi::Btn::Component.new) { 'Save' }
+    end
+  end
+end

--- a/test/components/previews/jet_ui/navbar/component_preview.rb
+++ b/test/components/previews/jet_ui/navbar/component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class JetUi::Navbar::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::Navbar::Component.new do
+      render(JetUi::Navbar::BrandComponent.new) { 'App Name' }
+      render(JetUi::Navbar::MainComponent.new) do
+        render(JetUi::Navbar::ActionsComponent.new) do
+          render(JetUi::Btn::Component.new(variant: :outline, size: :sm)) { 'Sign In' }
+        end
+      end
+    end
+  end
+
+  def non_sticky
+    render JetUi::Navbar::Component.new(sticky: false) do
+      render(JetUi::Navbar::BrandComponent.new) { 'Logo' }
+    end
+  end
+end

--- a/test/components/previews/jet_ui/popover/component_preview.rb
+++ b/test/components/previews/jet_ui/popover/component_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class JetUi::Popover::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::Popover::Component.new do
+      render(JetUi::Popover::TriggerComponent.new) { 'Hover me' }
+      render(JetUi::Popover::ContentComponent.new(title: 'Popover Title')) { 'Some content.' }
+    end
+  end
+
+  def placement_right
+    render JetUi::Popover::Component.new(placement: :right) do
+      render(JetUi::Popover::TriggerComponent.new) { 'Hover (right)' }
+      render(JetUi::Popover::ContentComponent.new) { 'Appears to the right.' }
+    end
+  end
+
+  def no_title
+    render JetUi::Popover::Component.new do
+      render(JetUi::Popover::TriggerComponent.new) { 'Hover me' }
+      render(JetUi::Popover::ContentComponent.new) { 'Simple popover without title.' }
+    end
+  end
+end

--- a/test/components/previews/jet_ui/sidebar/component_preview.rb
+++ b/test/components/previews/jet_ui/sidebar/component_preview.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class JetUi::Sidebar::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::Sidebar::Component.new do
+      render(JetUi::Sidebar::SectionComponent.new) do
+        render(JetUi::Sidebar::TitleComponent.new) { 'Navigation' }
+        render(JetUi::Sidebar::MenuComponent.new) do
+          render(JetUi::Sidebar::LinkComponent.new(url: '/')) { 'Home' }
+          render(JetUi::Sidebar::LinkComponent.new(url: '/about')) { 'About' }
+          render(JetUi::Sidebar::LinkComponent.new(disabled: true)) { 'Coming Soon' }
+        end
+      end
+    end
+  end
+
+  def with_active_link
+    render JetUi::Sidebar::Component.new do
+      render(JetUi::Sidebar::SectionComponent.new) do
+        render(JetUi::Sidebar::MenuComponent.new) do
+          render(JetUi::Sidebar::LinkComponent.new(url: '/', active: true)) { 'Active Link' }
+          render(JetUi::Sidebar::LinkComponent.new(url: '/other')) { 'Other Link' }
+        end
+      end
+    end
+  end
+end

--- a/test/components/previews/jet_ui/tooltip/component_preview.rb
+++ b/test/components/previews/jet_ui/tooltip/component_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class JetUi::Tooltip::ComponentPreview < ViewComponent::Preview
+  def top
+    render JetUi::Tooltip::Component.new(title: 'Top tooltip', placement: :top) { 'Hover (top)' }
+  end
+
+  def bottom
+    render JetUi::Tooltip::Component.new(title: 'Bottom tooltip', placement: :bottom) { 'Hover (bottom)' }
+  end
+
+  def left
+    render JetUi::Tooltip::Component.new(title: 'Left tooltip', placement: :left) { 'Hover (left)' }
+  end
+
+  def right
+    render JetUi::Tooltip::Component.new(title: 'Right tooltip', placement: :right) { 'Hover (right)' }
+  end
+end

--- a/test/components/previews/jet_ui/turbo_confirm/component_preview.rb
+++ b/test/components/previews/jet_ui/turbo_confirm/component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class JetUi::TurboConfirm::ComponentPreview < ViewComponent::Preview
+  def default
+    render JetUi::TurboConfirm::Component.new
+  end
+end


### PR DESCRIPTION
## Summary

- Ports 11 new ViewComponents with full Stimulus integration: **Accordion**, **Clipboard**, **Sidebar**, **Header**, **Navbar**, **Modal**, **Drawer**, **Dropdown**, **Tooltip**, **Popover**, **TurboConfirm**
- Vanilla JS replacements for `stimulus-use` and `@floating-ui/dom` — no external CDN dependencies required
- All CSS files follow the established `@layer theme, base, components, utilities` pattern; responsive behavior uses native `@media` queries (Tailwind v4 strips prefixes from `@apply`)
- Header converted from inline Tailwind classes to BEM CSS classes so Tailwind scans work correctly when installed as a gem
- `TurboConfirm` uses `window.Turbo` global instead of ES module import to stay compatible with the importmap setup
- Eject generator MANIFEST and `desc` updated to list all 26 components
- README components table updated with ⚡ indicators for JS-dependent components