### PR TITLE
feat: ship Stimulus controllers as an npm package for Vite + fix importmap crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /coverage/
 /vendor/bundle/
 Gemfile.lock
+node_modules
+/dist/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -37,6 +37,36 @@ The generator:
 
 When the gem is updated, both CSS and JS are picked up automatically — no further changes needed. Safe to re-run after upgrades.
 
+### Alternative: npm package (Vite)
+
+The above (importmap) setup needs no npm install — the gem ships the controllers itself. If your app bundles JavaScript with Vite instead, run the install generator: it detects Vite, **installs the `@jetrockets/jet_ui` npm package** for you (running `yarn add @jetrockets/jet_ui`, or the npm/pnpm/bun equivalent it detects), and prints the wiring steps:
+
+```bash
+rails generate jet_ui:install
+# detects Vite → runs: yarn add @jetrockets/jet_ui
+```
+
+Then register the controllers you use (`@hotwired/stimulus` is a peer dependency):
+
+```javascript
+import { ModalController } from "@jetrockets/jet_ui"
+
+application.register("modal", ModalController)
+```
+
+Import the component styles in your Tailwind/CSS entry point:
+
+```css
+@import "@jetrockets/jet_ui/css";
+```
+
+Or, if you'd rather manage styles through the bundler than the Rails asset pipeline, import the CSS straight from JavaScript:
+
+```javascript
+import "@jetrockets/jet_ui/css"          // all component styles
+import "@jetrockets/jet_ui/css/btn.css"  // a single component
+```
+
 ## Usage
 
 The `jet_ui` helper is available in all views:

--- a/lib/generators/jet_ui/install/install_generator.rb
+++ b/lib/generators/jet_ui/install/install_generator.rb
@@ -2,6 +2,7 @@
 
 require 'rails/generators'
 require_relative '../eject/eject_generator'
+require_relative '../js_runtime'
 
 module JetUi
   module Generators
@@ -12,24 +13,28 @@ module JetUi
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path('templates', __dir__)
 
+      class_option :skip_install, type: :boolean, default: false,
+                                  desc: 'Vite apps: skip running the package manager install, just print the command'
+
       desc <<~DESC
         JetUi is a ViewComponent-based UI library for Rails — #{EjectGenerator::MANIFEST.size} ready-made
         components styled with Tailwind CSS v4, matching the design system at
         ui.jetrockets.com.
 
-        This generator sets up JetUi in your Rails application:
+        This generator detects how your app manages JavaScript and sets JetUi up
+        accordingly — no flags needed:
 
-        1. CSS — Detects your Tailwind source file and injects a single @import
-           that covers all JetUi component stylesheets. New components added in
-           future gem updates are picked up automatically on the next CSS build.
+        • Importmap apps — injects the gem's CSS @import into your Tailwind source
+          and adds eagerLoadControllersFrom("jet_ui", application) to your Stimulus
+          controllers index. Controllers are auto-registered, no npm needed.
 
-        2. JS — Adds eagerLoadControllersFrom("jet_ui", application) to your
-           Stimulus controllers index. All current and future JetUi Stimulus
-           controllers are registered automatically when you update the gem.
+        • Vite apps — installs the npm package with your package manager and
+          prints the controller registration and stylesheet @import. Vite apps own
+          their JS/CSS entry points, so those are not modified automatically.
 
-        Safe to run multiple times — already-configured steps are skipped.
+        Safe to run multiple times — already-configured importmap steps are skipped.
 
-        Supported Tailwind source file locations:
+        Importmap Tailwind source files detected for the CSS @import:
           app/assets/tailwind/application.css
           app/assets/stylesheets/application.tailwind.css
           app/assets/stylesheets/application.postcss.css
@@ -41,40 +46,19 @@ module JetUi
           rails generate jet_ui:install
       DESC
 
-      def inject_css
-        if (file = tailwind_source_file)
-          content = File.read(File.join(destination_root, file))
-          if content.include?('jet_ui')
-            say "  JetUi CSS already imported in #{file}", :yellow
-          else
-            # Tailwind CSS v4: import each file with an absolute path so the
-            # Tailwind CLI can process @apply directives at build time.
-            append_to_file file, tailwind_imports
-            say "  Injected JetUi imports into #{file}", :green
-          end
-        else
-          say '  Could not detect a Tailwind CSS source file.', :yellow
-          say '  Add the following to your Tailwind CSS source manually:', :yellow
-          say tailwind_imports, :yellow
+      def show_runtime
+        case js_runtime
+        when :importmap then say '  Detected importmap — wiring JetUi via the gem.', :green
+        when :vite      then say '  Detected Vite — wiring JetUi via the npm package.', :green
+        else say '  Could not detect importmap or Vite — printing both setups.', :yellow
         end
       end
 
-      def inject_js
-        path = File.join(destination_root, JS_CONTROLLERS_FILE)
-        unless File.exist?(path)
-          say '  No Stimulus controllers index found — skipping JS setup.', :yellow
-          say '  If you use Stimulus, add this line to your controllers index manually:', :yellow
-          say %(    eagerLoadControllersFrom("jet_ui", application)), :yellow
-          return
-        end
-
-        if File.read(path).include?('jet_ui')
-          say "  JetUi controllers already registered in #{JS_CONTROLLERS_FILE}", :yellow
-        else
-          insert_into_file JS_CONTROLLERS_FILE, after: /eagerLoadControllersFrom\("controllers".*\n/ do
-            %(eagerLoadControllersFrom("jet_ui", application)\n)
-          end
-          say "  Registered JetUi controllers in #{JS_CONTROLLERS_FILE}", :green
+      def setup
+        case js_runtime
+        when :importmap then setup_importmap
+        when :vite      then setup_vite
+        else setup_unknown
         end
       end
 
@@ -96,6 +80,8 @@ module JetUi
         say "  rails generate jet_ui:eject btn card\n"
       end
 
+      NPM_PACKAGE = '@jetrockets/jet_ui'
+
       JS_CONTROLLERS_FILE = 'app/javascript/controllers/index.js'
 
       TAILWIND_SOURCE_FILES = %w[
@@ -106,8 +92,92 @@ module JetUi
 
       private
 
+      def js_runtime
+        @js_runtime ||= JsRuntime.detect(destination_root)
+      end
+
+      # --- importmap: auto-wire from the gem -------------------------------
+
+      def setup_importmap
+        inject_importmap_css
+        inject_importmap_controllers
+      end
+
+      def inject_importmap_css
+        file = tailwind_source_file
+        unless file
+          say '  Could not detect a Tailwind CSS source file.', :yellow
+          say '  Add the following to your Tailwind CSS source manually:', :yellow
+          say gem_css_import, :yellow
+          return
+        end
+
+        if File.read(File.join(destination_root, file)).include?('jet_ui')
+          say "  JetUi CSS already imported in #{file}", :yellow
+        else
+          # Tailwind CSS v4: import the gem's stylesheet by absolute path so the
+          # Tailwind CLI can process its @apply directives at build time.
+          append_to_file file, gem_css_import
+          say "  Injected JetUi CSS into #{file}", :green
+        end
+      end
+
+      def inject_importmap_controllers
+        path = File.join(destination_root, JS_CONTROLLERS_FILE)
+        unless File.exist?(path)
+          say '  No Stimulus controllers index found — add this line to it manually:', :yellow
+          say %(    eagerLoadControllersFrom("jet_ui", application)), :yellow
+          return
+        end
+
+        if File.read(path).include?('jet_ui')
+          say "  JetUi controllers already registered in #{JS_CONTROLLERS_FILE}", :yellow
+        else
+          insert_into_file JS_CONTROLLERS_FILE, after: /eagerLoadControllersFrom\("controllers".*\n/ do
+            %(eagerLoadControllersFrom("jet_ui", application)\n)
+          end
+          say "  Registered JetUi controllers in #{JS_CONTROLLERS_FILE}", :green
+        end
+      end
+
+      # --- vite: install the package, but never touch the app's entry points ---
+
+      def setup_vite
+        install_npm_package
+        say '  Ensure @hotwired/stimulus is installed — it is a peer dependency the controllers import.', :yellow
+        say '  Register the controllers you use, in your Stimulus controllers index:'
+        say %(    import { ModalController, DrawerController } from "#{NPM_PACKAGE}")
+        say %(    application.register("modal", ModalController))
+        say %(    application.register("drawer", DrawerController))
+        say '  Import the styles, in your Tailwind/CSS entry point:'
+        say %(    @import "#{NPM_PACKAGE}/css";)
+      end
+
+      def install_npm_package
+        command = JsRuntime.install_command(destination_root, NPM_PACKAGE)
+        if options[:skip_install]
+          say '  Skipped install — run it yourself:', :yellow
+          say "    #{command}"
+        else
+          say "  Installing #{NPM_PACKAGE}…", :green
+          run command
+        end
+      end
+
+      def setup_unknown
+        say '  Importmap apps — add to your Stimulus controllers index:', :yellow
+        say %(    eagerLoadControllersFrom("jet_ui", application))
+        say '  Vite apps — install the npm package and import its styles:', :yellow
+        say "    #{JsRuntime.install_command(destination_root, NPM_PACKAGE)}"
+        say %(    @import "#{NPM_PACKAGE}/css";)
+      end
+
       def tailwind_source_file
         TAILWIND_SOURCE_FILES.find { |f| File.exist?(File.join(destination_root, f)) }
+      end
+
+      def gem_css_import
+        %(\n@import "#{File.join(gem_stylesheets_path, 'jet_ui.css')}";\n)
       end
 
       def gem_stylesheets_path
@@ -118,10 +188,6 @@ module JetUi
         end
         base = spec&.gem_dir || File.expand_path('../../../../..', __dir__)
         File.join(base, 'app/assets/stylesheets')
-      end
-
-      def tailwind_imports
-        %(\n@import "#{File.join(gem_stylesheets_path, 'jet_ui.css')}";\n)
       end
     end
   end

--- a/lib/generators/jet_ui/js_runtime.rb
+++ b/lib/generators/jet_ui/js_runtime.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module JetUi
+  module Generators
+    # Detects how a host application manages its JavaScript, so the install
+    # generator can wire JetUi the right way without asking: pin controllers via
+    # importmap, or point the app at the npm package for Vite.
+    module JsRuntime
+      VITE_CONFIGS = %w[
+        vite.config.js vite.config.mjs vite.config.ts
+        config/vite.json
+      ].freeze
+
+      # Ordered: the first lockfile found wins.
+      PACKAGE_MANAGERS = {
+        'bun.lockb' => :bun,
+        'pnpm-lock.yaml' => :pnpm,
+        'yarn.lock' => :yarn,
+        'package-lock.json' => :npm
+      }.freeze
+
+      module_function
+
+      # Vite wins when both are present: a working Vite config is a stronger
+      # signal than a leftover config/importmap.rb.
+      def detect(root)
+        return :vite if vite?(root)
+        return :importmap if importmap?(root)
+
+        :unknown
+      end
+
+      def vite?(root)
+        VITE_CONFIGS.any? { |file| File.exist?(File.join(root, file)) } ||
+          package_json_vite?(root)
+      end
+
+      def importmap?(root)
+        File.exist?(File.join(root, 'config/importmap.rb'))
+      end
+
+      def package_manager(root)
+        PACKAGE_MANAGERS.each { |lock, name| return name if File.exist?(File.join(root, lock)) }
+        package_manager_field(root) || :npm
+      end
+
+      # corepack's `"packageManager": "yarn@4.5.0"` — the declared manager when
+      # there's no lockfile yet (e.g. a fresh vite_rails clone).
+      def package_manager_field(root)
+        path = File.join(root, 'package.json')
+        return unless File.exist?(path)
+
+        field = JSON.parse(File.read(path))['packageManager']
+        return unless field
+
+        PACKAGE_MANAGERS.values.find { |name| name.to_s == field.split('@').first }
+      rescue JSON::ParserError
+        nil
+      end
+
+      def install_command(root, package)
+        manager = package_manager(root)
+        verb = manager == :npm ? 'install' : 'add'
+
+        "#{manager} #{verb} #{package}"
+      end
+
+      def package_json_vite?(root)
+        path = File.join(root, 'package.json')
+        return false unless File.exist?(path)
+
+        deps = JSON.parse(File.read(path)).values_at('dependencies', 'devDependencies').compact
+        deps.flat_map(&:keys).include?('vite')
+      rescue JSON::ParserError
+        false
+      end
+    end
+  end
+end

--- a/lib/jet_ui/engine.rb
+++ b/lib/jet_ui/engine.rb
@@ -17,7 +17,6 @@ module JetUi
           root.join('app/assets/javascripts/jet_ui'),
           under: 'jet_ui'
         )
-        app.config.importmap.paths << root.join('app/assets/javascripts')
         app.config.importmap.cache_sweepers << root.join('app/assets/javascripts')
       end
     end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@jetrockets/jet_ui",
+  "version": "0.2.7",
+  "description": "Stimulus controllers for JetRockets jet_ui Rails components",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/jet_ui.umd.cjs",
+  "module": "src/index.js",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/jet_ui.umd.cjs"
+    },
+    "./css": "./app/assets/stylesheets/jet_ui.css",
+    "./css/*": "./app/assets/stylesheets/jet_ui/*"
+  },
+  "files": [
+    "dist",
+    "src",
+    "app/assets/javascripts",
+    "app/assets/stylesheets"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "prepare": "vite build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@hotwired/stimulus": "^3.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jetrockets/jet_ui"
+  },
+  "homepage": "https://ui.jetrockets.com",
+  "keywords": [
+    "stimulus",
+    "stimulusjs",
+    "rails",
+    "jet_ui",
+    "jetrockets",
+    "viewcomponent"
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,23 @@
+import ClipboardController from '../app/assets/javascripts/jet_ui/clipboard_controller.js'
+import DrawerController from '../app/assets/javascripts/jet_ui/drawer_controller.js'
+import DrawersController from '../app/assets/javascripts/jet_ui/drawers_controller.js'
+import DropdownController from '../app/assets/javascripts/jet_ui/dropdown_controller.js'
+import FlashController from '../app/assets/javascripts/jet_ui/flash_controller.js'
+import ModalController from '../app/assets/javascripts/jet_ui/modal_controller.js'
+import ModalsController from '../app/assets/javascripts/jet_ui/modals_controller.js'
+import PopoverController from '../app/assets/javascripts/jet_ui/popover_controller.js'
+import TooltipController from '../app/assets/javascripts/jet_ui/tooltip_controller.js'
+import TurboConfirmController from '../app/assets/javascripts/jet_ui/turbo_confirm_controller.js'
+
+export {
+  ClipboardController,
+  DrawerController,
+  DrawersController,
+  DropdownController,
+  FlashController,
+  ModalController,
+  ModalsController,
+  PopoverController,
+  TooltipController,
+  TurboConfirmController
+}

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -1,20 +1,91 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'rails/generators/test_case'
 require 'generators/jet_ui/install/install_generator'
 
-class InstallGeneratorTest < Minitest::Test
+class InstallGeneratorTest < Rails::Generators::TestCase
+  tests JetUi::Generators::InstallGenerator
+  destination File.expand_path('../../tmp/install_generator', __dir__)
+  setup :prepare_destination
+
+  PACKAGE = JetUi::Generators::InstallGenerator::NPM_PACKAGE
+  TAILWIND_HEADER = %(@import "tailwindcss";\n)
+  TAILWIND_SOURCE = 'app/assets/tailwind/application.css'
+  CONTROLLERS_INDEX = 'app/javascript/controllers/index.js'
+
   def test_desc_includes_gem_overview
-    assert_match(/ViewComponent/, JetUi::Generators::InstallGenerator.desc)
+    assert_match(/ViewComponent/, description)
   end
 
   def test_desc_includes_pointer_to_eject_help
-    assert_match(/jet_ui:eject/, JetUi::Generators::InstallGenerator.desc)
+    assert_match(/jet_ui:eject/, description)
   end
 
   def test_desc_includes_component_count
     count = JetUi::Generators::EjectGenerator::MANIFEST.size.to_s
 
-    assert_includes JetUi::Generators::InstallGenerator.desc, count
+    assert_includes description, count
+  end
+
+  def test_vite_app_prints_setup_and_uses_detected_package_manager
+    scaffold_vite_app
+    write('app/assets/entrypoints/tailwind.css', TAILWIND_HEADER)
+
+    output = run_generator(['--skip-install'])
+
+    assert_match(/yarn add #{Regexp.escape(PACKAGE)}/, output)
+    assert_match(%r{@hotwired/stimulus}, output)
+    assert_match(%r{@import "#{Regexp.escape(PACKAGE)}/css";}, output)
+    assert_no_match(/eagerLoadControllersFrom\("jet_ui"/, output)
+    # Vite apps own their entry points — the generator must not edit them.
+    assert_file 'app/assets/entrypoints/tailwind.css' do |content|
+      assert_equal TAILWIND_HEADER, content
+    end
+  end
+
+  def test_importmap_app_injects_eager_load_and_gem_css
+    scaffold_importmap_app
+
+    run_generator
+
+    assert_file CONTROLLERS_INDEX do |content|
+      assert_match(/eagerLoadControllersFrom\("jet_ui", application\)/, content)
+    end
+    assert_file TAILWIND_SOURCE do |content|
+      assert_match(/jet_ui\.css/, content)
+    end
+  end
+
+  def test_unknown_runtime_prints_both_setups
+    write(TAILWIND_SOURCE, TAILWIND_HEADER)
+
+    output = run_generator
+
+    assert_match(/eagerLoadControllersFrom\("jet_ui", application\)/, output)
+    assert_match(/npm install #{Regexp.escape(PACKAGE)}/, output)
+  end
+
+  private
+
+  def description
+    JetUi::Generators::InstallGenerator.desc
+  end
+
+  def scaffold_vite_app
+    write('vite.config.mjs', 'export default {}')
+    write('yarn.lock', '')
+  end
+
+  def scaffold_importmap_app
+    write('config/importmap.rb', 'pin "application"')
+    write(TAILWIND_SOURCE, TAILWIND_HEADER)
+    write(CONTROLLERS_INDEX, %(eagerLoadControllersFrom("controllers", application)\n))
+  end
+
+  def write(path, content)
+    full = File.join(destination_root, path)
+    FileUtils.mkdir_p(File.dirname(full))
+    File.write(full, content)
   end
 end

--- a/test/generators/js_runtime_test.rb
+++ b/test/generators/js_runtime_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'generators/jet_ui/js_runtime'
+
+class JsRuntimeTest < Minitest::Test
+  Runtime = JetUi::Generators::JsRuntime
+
+  def test_detects_importmap_from_config_file
+    in_app('config/importmap.rb' => 'pin "application"') do |root|
+      assert_equal :importmap, Runtime.detect(root)
+    end
+  end
+
+  def test_detects_vite_from_config
+    in_app('vite.config.mjs' => 'export default {}') do |root|
+      assert_equal :vite, Runtime.detect(root)
+    end
+  end
+
+  def test_vite_wins_when_both_present
+    in_app('config/importmap.rb' => 'pin "application"', 'vite.config.mjs' => 'export default {}') do |root|
+      assert_equal :vite, Runtime.detect(root)
+    end
+  end
+
+  def test_detects_vite_from_package_json_dependency
+    in_app('package.json' => '{"devDependencies":{"vite":"^6"}}') do |root|
+      assert_equal :vite, Runtime.detect(root)
+    end
+  end
+
+  def test_package_json_without_vite_is_not_a_vite_app
+    in_app('package.json' => '{"dependencies":{"left-pad":"^1"}}') do |root|
+      assert_equal :unknown, Runtime.detect(root)
+    end
+  end
+
+  def test_unknown_when_nothing_present
+    in_app({}) do |root|
+      assert_equal :unknown, Runtime.detect(root)
+    end
+  end
+
+  def test_package_manager_from_lockfile
+    {
+      'yarn.lock' => :yarn,
+      'pnpm-lock.yaml' => :pnpm,
+      'bun.lockb' => :bun,
+      'package-lock.json' => :npm
+    }.each do |lockfile, manager|
+      in_app(lockfile => '') do |root|
+        assert_equal manager, Runtime.package_manager(root), "expected #{lockfile} → #{manager}"
+      end
+    end
+  end
+
+  def test_package_manager_reads_package_manager_field_without_lockfile
+    in_app('package.json' => '{"packageManager":"yarn@4.5.0"}') do |root|
+      assert_equal :yarn, Runtime.package_manager(root)
+    end
+  end
+
+  def test_lockfile_beats_package_manager_field
+    in_app('package.json' => '{"packageManager":"yarn@4.5.0"}', 'package-lock.json' => '{}') do |root|
+      assert_equal :npm, Runtime.package_manager(root)
+    end
+  end
+
+  def test_package_manager_defaults_to_npm
+    in_app({}) { |root| assert_equal :npm, Runtime.package_manager(root) }
+  end
+
+  def test_install_command_uses_add_for_yarn_and_install_for_npm
+    in_app('yarn.lock' => '') do |root|
+      assert_equal 'yarn add @scope/pkg', Runtime.install_command(root, '@scope/pkg')
+    end
+    in_app({}) do |root|
+      assert_equal 'npm install @scope/pkg', Runtime.install_command(root, '@scope/pkg')
+    end
+  end
+
+  private
+
+  def in_app(files)
+    Dir.mktmpdir do |root|
+      files.each do |path, content|
+        full = File.join(root, path)
+        FileUtils.mkdir_p(File.dirname(full))
+        File.write(full, content)
+      end
+      yield root
+    end
+  end
+end

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,23 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    minifyIdentifiers: false
+  },
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.js'),
+      name: 'JetUi',
+      fileName: 'jet_ui'
+    },
+    rollupOptions: {
+      external: ['@hotwired/stimulus'],
+      output: {
+        globals: {
+          '@hotwired/stimulus': 'Stimulus'
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
Three changes, all about getting JetUi's Stimulus controllers into apps that don't use importmap — plus a crash fix found along the way.

## npm package
Importmap apps get the controllers straight from the gem. Vite apps had no way in. This ships them as an npm package:

```js
import { ModalController } from "@jetrockets/jet-ui"
application.register("modal", ModalController)
```
```css
@import "@jetrockets/jet-ui/css";   /* all component styles */
```

Bundlers resolve straight from `src/` — no build step, works with `github:` installs too. A `dist/` UMD build is produced on publish for `require`/CDN. `@hotwired/stimulus` is a peer dependency.

## importmap crash fix
The engine added a **directory** to `importmap.paths`, but `paths` expects files — so the importmap reloader tripped over it (`Importmap::Map::InvalidFile`) and crashed on reload. `pin_all_from` already registers the controllers, so that line was a buggy no-op. Removed.

## `jet_ui:install` auto-detects the setup
No flags — the generator figures out how the app loads JS:

- **importmap** → injects the CSS `@import` and `eagerLoadControllersFrom("jet_ui", …)`.
- **Vite** → installs the npm package (yarn/npm/pnpm/bun, auto-detected from the lockfile) and **prints** the controller-registration + CSS snippets instead of editing files.

### Why Vite is print-only, not auto-edited
Importmap apps follow Rails conventions — fixed paths (`app/javascript/controllers/index.js`, the Tailwind source) and a known `eagerLoadControllersFrom("controllers")` line to splice after. High confidence → safe to auto-edit.

Vite apps have no such convention: the entry point may live in `app/javascript/entrypoints/`, `app/frontend/entrypoints/`, or elsewhere; the CSS entry and Stimulus wiring vary per app. Guessing the file means editing the wrong one (and a CSS `@import` appended anywhere but the top is invalid). So for Vite we only do what's safe and universal — install the package (no path guessing) — and print the rest for the developer to place. Detection itself never edits anything.

## Tested
End-to-end in two fresh Rails 8 apps, plus the unit suite:

- **importmap app** (`rails new --css=tailwind`): generator detects importmap, injects the CSS `@import` + `eagerLoadControllersFrom("jet_ui", …)`, the app **boots with no `Importmap::Map::InvalidFile`**, and all 10 controllers are pinned. This is the regression the crash fix targets.
- **Vite app** (`rails new` + `vite_rails`): generator detects Vite, runs the correct package-manager install, and **makes zero file edits** (verified by checksum). `vite build` then resolves both the JS import and `@jetrockets/jet-ui/css`. The app's entry point turned out to be `app/frontend/entrypoints/` — a path the generator would never have guessed, which is exactly why auto-edit is the wrong call here.

Full minitest suite green; RuboCop clean.

---

> ⚠️ The package is temporarily published under a personal scope (`@islam_gagiev_101/jet-ui`) for end-to-end testing, since there's no access to the `jetrockets` npm org yet. Before release: rename to `@jetrockets/jet-ui` (generator constant, README, package.json) and publish as a maintainer (see the inline comment on `package.json`).