### PR TITLE
chore: Add previews for Alert, Badge, Group, and Stat

### DIFF
--- a/test/components/previews/jet_ui/alert/component_preview.rb
+++ b/test/components/previews/jet_ui/alert/component_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# @label Alert
+class JetUi::Alert::ComponentPreview < ViewComponent::Preview
+  # @label Default
+  def default
+    render(JetUi::Alert::Component.new) { 'This is a default alert.' }
+  end
+
+  # @label Success
+  def success
+    render(JetUi::Alert::Component.new(variant: :success)) do
+      safe_join([
+        render(JetUi::Alert::TitleComponent.new) { 'Success' },
+        render(JetUi::Alert::DescriptionComponent.new) { 'Your changes have been saved.' }
+      ])
+    end
+  end
+
+  # @label Error
+  def error
+    render(JetUi::Alert::Component.new(variant: :error)) do
+      safe_join([
+        render(JetUi::Alert::TitleComponent.new) { 'Unable to save changes' },
+        render(JetUi::Alert::DescriptionComponent.new) { 'Check the form and try again.' }
+      ])
+    end
+  end
+end

--- a/test/components/previews/jet_ui/alert/component_preview.rb
+++ b/test/components/previews/jet_ui/alert/component_preview.rb
@@ -9,21 +9,11 @@ class JetUi::Alert::ComponentPreview < ViewComponent::Preview
 
   # @label Success
   def success
-    render(JetUi::Alert::Component.new(variant: :success)) do
-      safe_join([
-        render(JetUi::Alert::TitleComponent.new) { 'Success' },
-        render(JetUi::Alert::DescriptionComponent.new) { 'Your changes have been saved.' }
-      ])
-    end
+    render_with_template
   end
 
   # @label Error
   def error
-    render(JetUi::Alert::Component.new(variant: :error)) do
-      safe_join([
-        render(JetUi::Alert::TitleComponent.new) { 'Unable to save changes' },
-        render(JetUi::Alert::DescriptionComponent.new) { 'Check the form and try again.' }
-      ])
-    end
+    render_with_template
   end
 end

--- a/test/components/previews/jet_ui/alert/component_preview/error.html.erb
+++ b/test/components/previews/jet_ui/alert/component_preview/error.html.erb
@@ -1,0 +1,4 @@
+<%= render(JetUi::Alert::Component.new(variant: :error)) do %>
+  <%= render(JetUi::Alert::TitleComponent.new) { 'Unable to save changes' } %>
+  <%= render(JetUi::Alert::DescriptionComponent.new) { 'Check the form and try again.' } %>
+<% end %>

--- a/test/components/previews/jet_ui/alert/component_preview/success.html.erb
+++ b/test/components/previews/jet_ui/alert/component_preview/success.html.erb
@@ -1,0 +1,4 @@
+<%= render(JetUi::Alert::Component.new(variant: :success)) do %>
+  <%= render(JetUi::Alert::TitleComponent.new) { 'Success' } %>
+  <%= render(JetUi::Alert::DescriptionComponent.new) { 'Your changes have been saved.' } %>
+<% end %>

--- a/test/components/previews/jet_ui/badge/component_preview.rb
+++ b/test/components/previews/jet_ui/badge/component_preview.rb
@@ -9,18 +9,11 @@ class JetUi::Badge::ComponentPreview < ViewComponent::Preview
 
   # @label Variants
   def variants
-    safe_join([
-      render(JetUi::Badge::Component.new(variant: :info)) { 'Info' },
-      render(JetUi::Badge::Component.new(variant: :success)) { 'Success' },
-      render(JetUi::Badge::Component.new(variant: :warning)) { 'Warning' },
-      render(JetUi::Badge::Component.new(variant: :error)) { 'Error' }
-    ], ' ')
+    render_with_template
   end
 
   # @label Sizes
   def sizes
-    safe_join(JetUi::Badge::Component::SIZES.map { |size|
-      render(JetUi::Badge::Component.new(size: size)) { size.to_s.upcase }
-    }, ' ')
+    render_with_template
   end
 end

--- a/test/components/previews/jet_ui/badge/component_preview.rb
+++ b/test/components/previews/jet_ui/badge/component_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# @label Badge
+class JetUi::Badge::ComponentPreview < ViewComponent::Preview
+  # @label Default
+  def default
+    render(JetUi::Badge::Component.new) { 'Default' }
+  end
+
+  # @label Variants
+  def variants
+    safe_join([
+      render(JetUi::Badge::Component.new(variant: :info)) { 'Info' },
+      render(JetUi::Badge::Component.new(variant: :success)) { 'Success' },
+      render(JetUi::Badge::Component.new(variant: :warning)) { 'Warning' },
+      render(JetUi::Badge::Component.new(variant: :error)) { 'Error' }
+    ], ' ')
+  end
+
+  # @label Sizes
+  def sizes
+    safe_join(JetUi::Badge::Component::SIZES.map { |size|
+      render(JetUi::Badge::Component.new(size: size)) { size.to_s.upcase }
+    }, ' ')
+  end
+end

--- a/test/components/previews/jet_ui/badge/component_preview/sizes.html.erb
+++ b/test/components/previews/jet_ui/badge/component_preview/sizes.html.erb
@@ -1,0 +1,5 @@
+<div class="flex items-center gap-2">
+  <% JetUi::Badge::Component::SIZES.each do |size| %>
+    <%= render(JetUi::Badge::Component.new(size: size)) { size.to_s.upcase } %>
+  <% end %>
+</div>

--- a/test/components/previews/jet_ui/badge/component_preview/variants.html.erb
+++ b/test/components/previews/jet_ui/badge/component_preview/variants.html.erb
@@ -1,0 +1,6 @@
+<div class="flex gap-2">
+  <%= render(JetUi::Badge::Component.new(variant: :info)) { 'Info' } %>
+  <%= render(JetUi::Badge::Component.new(variant: :success)) { 'Success' } %>
+  <%= render(JetUi::Badge::Component.new(variant: :warning)) { 'Warning' } %>
+  <%= render(JetUi::Badge::Component.new(variant: :error)) { 'Error' } %>
+</div>

--- a/test/components/previews/jet_ui/group/component_preview.rb
+++ b/test/components/previews/jet_ui/group/component_preview.rb
@@ -4,21 +4,11 @@
 class JetUi::Group::ComponentPreview < ViewComponent::Preview
   # @label Sticky
   def sticky
-    render(JetUi::Group::Component.new) do
-      safe_join([
-        render(JetUi::Btn::Component.new(variant: :outline)) { 'Cancel' },
-        render(JetUi::Btn::Component.new) { 'Save changes' }
-      ], ' ')
-    end
+    render_with_template
   end
 
   # @label Non-sticky
   def non_sticky
-    render(JetUi::Group::Component.new(sticky: false)) do
-      safe_join([
-        render(JetUi::Btn::Component.new(variant: :outline)) { 'Back' },
-        render(JetUi::Btn::Component.new(variant: :secondary)) { 'Continue' }
-      ], ' ')
-    end
+    render_with_template
   end
 end

--- a/test/components/previews/jet_ui/group/component_preview.rb
+++ b/test/components/previews/jet_ui/group/component_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# @label Group
+class JetUi::Group::ComponentPreview < ViewComponent::Preview
+  # @label Sticky
+  def sticky
+    render(JetUi::Group::Component.new) do
+      safe_join([
+        render(JetUi::Btn::Component.new(variant: :outline)) { 'Cancel' },
+        render(JetUi::Btn::Component.new) { 'Save changes' }
+      ], ' ')
+    end
+  end
+
+  # @label Non-sticky
+  def non_sticky
+    render(JetUi::Group::Component.new(sticky: false)) do
+      safe_join([
+        render(JetUi::Btn::Component.new(variant: :outline)) { 'Back' },
+        render(JetUi::Btn::Component.new(variant: :secondary)) { 'Continue' }
+      ], ' ')
+    end
+  end
+end

--- a/test/components/previews/jet_ui/group/component_preview/non_sticky.html.erb
+++ b/test/components/previews/jet_ui/group/component_preview/non_sticky.html.erb
@@ -1,0 +1,4 @@
+<%= render(JetUi::Group::Component.new(sticky: false)) do %>
+  <%= render(JetUi::Btn::Component.new(variant: :outline)) { 'Back' } %>
+  <%= render(JetUi::Btn::Component.new(variant: :secondary)) { 'Continue' } %>
+<% end %>

--- a/test/components/previews/jet_ui/group/component_preview/sticky.html.erb
+++ b/test/components/previews/jet_ui/group/component_preview/sticky.html.erb
@@ -1,0 +1,4 @@
+<%= render(JetUi::Group::Component.new) do %>
+  <%= render(JetUi::Btn::Component.new(variant: :outline)) { 'Cancel' } %>
+  <%= render(JetUi::Btn::Component.new) { 'Save changes' } %>
+<% end %>

--- a/test/components/previews/jet_ui/stat/component_preview.rb
+++ b/test/components/previews/jet_ui/stat/component_preview.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# @label Stat
+class JetUi::Stat::ComponentPreview < ViewComponent::Preview
+  # @label Default
+  def default
+    render_stat(label: 'Total revenue', value: '$24,780', description: 'This month')
+  end
+
+  # @label Positive trend
+  def positive_trend
+    render_stat(
+      label: 'Active users',
+      value: '2,340',
+      description: '12% from last month',
+      variant: :success
+    )
+  end
+
+  # @label Negative trend
+  def negative_trend
+    render_stat(
+      label: 'Conversion rate',
+      value: '3.2%',
+      description: '0.8% from last month',
+      variant: :error
+    )
+  end
+
+  private
+
+  def render_stat(label:, value:, description:, variant: :default)
+    render(JetUi::Stat::Component.new) do
+      safe_join([
+        render(JetUi::Stat::LabelComponent.new) { label },
+        render(JetUi::Stat::ValueComponent.new) { value },
+        render(JetUi::Stat::DescriptionComponent.new(variant: variant)) { description }
+      ])
+    end
+  end
+end

--- a/test/components/previews/jet_ui/stat/component_preview.rb
+++ b/test/components/previews/jet_ui/stat/component_preview.rb
@@ -4,38 +4,16 @@
 class JetUi::Stat::ComponentPreview < ViewComponent::Preview
   # @label Default
   def default
-    render_stat(label: 'Total revenue', value: '$24,780', description: 'This month')
+    render_with_template
   end
 
   # @label Positive trend
   def positive_trend
-    render_stat(
-      label: 'Active users',
-      value: '2,340',
-      description: '12% from last month',
-      variant: :success
-    )
+    render_with_template
   end
 
   # @label Negative trend
   def negative_trend
-    render_stat(
-      label: 'Conversion rate',
-      value: '3.2%',
-      description: '0.8% from last month',
-      variant: :error
-    )
-  end
-
-  private
-
-  def render_stat(label:, value:, description:, variant: :default)
-    render(JetUi::Stat::Component.new) do
-      safe_join([
-        render(JetUi::Stat::LabelComponent.new) { label },
-        render(JetUi::Stat::ValueComponent.new) { value },
-        render(JetUi::Stat::DescriptionComponent.new(variant: variant)) { description }
-      ])
-    end
+    render_with_template
   end
 end

--- a/test/components/previews/jet_ui/stat/component_preview/default.html.erb
+++ b/test/components/previews/jet_ui/stat/component_preview/default.html.erb
@@ -1,0 +1,5 @@
+<%= render(JetUi::Stat::Component.new) do %>
+  <%= render(JetUi::Stat::LabelComponent.new) { 'Total revenue' } %>
+  <%= render(JetUi::Stat::ValueComponent.new) { '$24,780' } %>
+  <%= render(JetUi::Stat::DescriptionComponent.new) { 'This month' } %>
+<% end %>

--- a/test/components/previews/jet_ui/stat/component_preview/negative_trend.html.erb
+++ b/test/components/previews/jet_ui/stat/component_preview/negative_trend.html.erb
@@ -1,0 +1,5 @@
+<%= render(JetUi::Stat::Component.new) do %>
+  <%= render(JetUi::Stat::LabelComponent.new) { 'Conversion rate' } %>
+  <%= render(JetUi::Stat::ValueComponent.new) { '3.2%' } %>
+  <%= render(JetUi::Stat::DescriptionComponent.new(variant: :error)) { '0.8% from last month' } %>
+<% end %>

--- a/test/components/previews/jet_ui/stat/component_preview/positive_trend.html.erb
+++ b/test/components/previews/jet_ui/stat/component_preview/positive_trend.html.erb
@@ -1,0 +1,5 @@
+<%= render(JetUi::Stat::Component.new) do %>
+  <%= render(JetUi::Stat::LabelComponent.new) { 'Active users' } %>
+  <%= render(JetUi::Stat::ValueComponent.new) { '2,340' } %>
+  <%= render(JetUi::Stat::DescriptionComponent.new(variant: :success)) { '12% from last month' } %>
+<% end %>


### PR DESCRIPTION
## Summary
- add ViewComponent previews for Alert, Badge, Group, and Stat
- cover alert and stat states plus badge sizes and variants

Closes #8

## Verification
- `ruby -c` for each new preview
- `git diff --check`

`bundle exec rake test` was not run because Bundler is not installed in this environment.