### PR TITLE
feat(a11y): Add ARIA roles and keyboard navigation to interactive components

### DIFF
--- a/app/assets/javascripts/jet_ui/clipboard_controller.js
+++ b/app/assets/javascripts/jet_ui/clipboard_controller.js
@@ -14,7 +14,8 @@ export default class ClipboardController extends Controller {
       : this.element.textContent
   }
 
-  async copy() {
+  async copy(event) {
+    event?.preventDefault()
     const text = this.#getContent()
     await navigator.clipboard.writeText(text)
 

--- a/app/assets/javascripts/jet_ui/drawer_controller.js
+++ b/app/assets/javascripts/jet_ui/drawer_controller.js
@@ -6,18 +6,25 @@ export default class DrawerController extends Controller {
   }
 
   connect() {
-    this.element.addEventListener("click", this.#closeOnBackdropClick.bind(this))
-    this.element.addEventListener("touchstart", this.#onTouchStart.bind(this), { passive: true })
-    this.element.addEventListener("touchmove", this.#onTouchMove.bind(this), { passive: true })
-    this.element.addEventListener("touchend", this.#onTouchEnd.bind(this), { passive: true })
+    this._closeOnBackdropClick = this.#closeOnBackdropClick.bind(this)
+    this._closeOnCancel = this.#closeOnCancel.bind(this)
+    this._onTouchStart = this.#onTouchStart.bind(this)
+    this._onTouchMove = this.#onTouchMove.bind(this)
+    this._onTouchEnd = this.#onTouchEnd.bind(this)
+    this.element.addEventListener("click", this._closeOnBackdropClick)
+    this.element.addEventListener("cancel", this._closeOnCancel)
+    this.element.addEventListener("touchstart", this._onTouchStart, { passive: true })
+    this.element.addEventListener("touchmove", this._onTouchMove, { passive: true })
+    this.element.addEventListener("touchend", this._onTouchEnd, { passive: true })
     this.element.showModal()
   }
 
   disconnect() {
-    this.element.removeEventListener("click", this.#closeOnBackdropClick.bind(this))
-    this.element.removeEventListener("touchstart", this.#onTouchStart.bind(this))
-    this.element.removeEventListener("touchmove", this.#onTouchMove.bind(this))
-    this.element.removeEventListener("touchend", this.#onTouchEnd.bind(this))
+    this.element.removeEventListener("click", this._closeOnBackdropClick)
+    this.element.removeEventListener("cancel", this._closeOnCancel)
+    this.element.removeEventListener("touchstart", this._onTouchStart)
+    this.element.removeEventListener("touchmove", this._onTouchMove)
+    this.element.removeEventListener("touchend", this._onTouchEnd)
     this.close()
   }
 
@@ -37,6 +44,11 @@ export default class DrawerController extends Controller {
     if (event.target === this.element) {
       this.close()
     }
+  }
+
+  #closeOnCancel(event) {
+    event.preventDefault()
+    this.close()
   }
 
   #onTouchStart(event) {

--- a/app/assets/javascripts/jet_ui/dropdown_controller.js
+++ b/app/assets/javascripts/jet_ui/dropdown_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class DropdownController extends Controller {
-  static targets = ["menu", "autofocus"]
+  static targets = ["menu", "autofocus", "trigger"]
   static values = { open: { type: Boolean, default: false } }
 
   connect() {
@@ -11,6 +11,7 @@ export default class DropdownController extends Controller {
     this._handleMorph = this.#handleMorph.bind(this)
     this.element.addEventListener("click", this._handleClick)
     document.addEventListener("turbo:morph", this._handleMorph)
+    this.#hideMenu()
   }
 
   disconnect() {
@@ -37,6 +38,8 @@ export default class DropdownController extends Controller {
   #showMenu() {
     this.menuTarget.classList.remove("hidden")
     this.menuTarget.classList.add("block")
+    this.menuTarget.setAttribute("aria-hidden", "false")
+    this.#setExpanded(true)
     this.#updatePosition()
     if (this.hasAutofocusTarget) this.autofocusTarget.focus()
     document.addEventListener("click", this._clickOutside)
@@ -46,12 +49,17 @@ export default class DropdownController extends Controller {
   #hideMenu() {
     this.menuTarget.classList.remove("block")
     this.menuTarget.classList.add("hidden")
+    this.menuTarget.setAttribute("aria-hidden", "true")
+    this.#setExpanded(false)
     document.removeEventListener("click", this._clickOutside)
     document.removeEventListener("keydown", this._handleKeydown)
   }
 
   #handleKeydown(event) {
-    if (event.key === "Escape") this.hide()
+    if (event.key === "Escape") {
+      this.hide()
+      if (this.hasTriggerTarget) this.triggerTarget.focus()
+    }
   }
 
   #clickOutside(event) {
@@ -60,6 +68,10 @@ export default class DropdownController extends Controller {
 
   #handleMorph() {
     if (this.openValue) this.#showMenu()
+  }
+
+  #setExpanded(isOpen) {
+    if (this.hasTriggerTarget) this.triggerTarget.setAttribute("aria-expanded", isOpen)
   }
 
   #updatePosition() {

--- a/app/assets/javascripts/jet_ui/modal_controller.js
+++ b/app/assets/javascripts/jet_ui/modal_controller.js
@@ -2,12 +2,16 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class ModalController extends Controller {
   connect() {
-    this.element.addEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this._closeOnBackdropClick = this.#closeOnBackdropClick.bind(this)
+    this._closeOnCancel = this.#closeOnCancel.bind(this)
+    this.element.addEventListener("click", this._closeOnBackdropClick)
+    this.element.addEventListener("cancel", this._closeOnCancel)
     this.element.showModal()
   }
 
   disconnect() {
-    this.element.removeEventListener("click", this.#closeOnBackdropClick.bind(this))
+    this.element.removeEventListener("click", this._closeOnBackdropClick)
+    this.element.removeEventListener("cancel", this._closeOnCancel)
     this.close()
   }
 
@@ -27,6 +31,11 @@ export default class ModalController extends Controller {
     if (event.target === this.element) {
       this.close()
     }
+  }
+
+  #closeOnCancel(event) {
+    event.preventDefault()
+    this.close()
   }
 
   static get turboFrame() {

--- a/app/assets/javascripts/jet_ui/tooltip_controller.js
+++ b/app/assets/javascripts/jet_ui/tooltip_controller.js
@@ -7,17 +7,23 @@ export default class TooltipController extends Controller {
   }
 
   connect() {
-    this._mouseEnter = this.#mouseEnter.bind(this)
-    this._mouseLeave = this.#mouseLeave.bind(this)
-    this.element.addEventListener("mouseenter", this._mouseEnter)
-    this.element.addEventListener("mouseleave", this._mouseLeave)
+    this._show = this.#show.bind(this)
+    this._hide = this.#hide.bind(this)
+    this._handleKeydown = this.#handleKeydown.bind(this)
+    this.element.addEventListener("mouseenter", this._show)
+    this.element.addEventListener("mouseleave", this._hide)
+    this.element.addEventListener("focus", this._show)
+    this.element.addEventListener("blur", this._hide)
+    this.element.addEventListener("keydown", this._handleKeydown)
   }
 
   disconnect() {
-    this.element.removeEventListener("mouseenter", this._mouseEnter)
-    this.element.removeEventListener("mouseleave", this._mouseLeave)
-    this.tooltip?.remove()
-    this.tooltip = null
+    this.element.removeEventListener("mouseenter", this._show)
+    this.element.removeEventListener("mouseleave", this._hide)
+    this.element.removeEventListener("focus", this._show)
+    this.element.removeEventListener("blur", this._hide)
+    this.element.removeEventListener("keydown", this._handleKeydown)
+    this.#hide()
   }
 
   updateContent(event) {
@@ -32,21 +38,29 @@ export default class TooltipController extends Controller {
     }
   }
 
-  #mouseEnter() {
+  #show() {
     this.#createTooltip()
     this.#updatePosition()
   }
 
-  #mouseLeave() {
+  #hide() {
     this.tooltip?.remove()
     this.tooltip = null
+    this.element.removeAttribute("aria-describedby")
+  }
+
+  #handleKeydown(event) {
+    if (event.key === "Escape") this.#hide()
   }
 
   #createTooltip() {
+    this.#hide()
     this.tooltip = document.createElement("div")
     this.tooltip.className = "tooltip"
+    this.tooltip.id = `tooltip-${crypto.randomUUID()}`
     this.tooltip.role = "tooltip"
     this.tooltip.innerHTML = this.contentValue
+    this.element.setAttribute("aria-describedby", this.tooltip.id)
     const container = this.element.closest("dialog") || document.body
     container.appendChild(this.tooltip)
   }

--- a/app/components/jet_ui/clipboard/component.rb
+++ b/app/components/jet_ui/clipboard/component.rb
@@ -3,6 +3,8 @@
 module JetUi
   module Clipboard
     class Component < JetUi::BaseComponent
+      COPY_ACTION = 'click->clipboard#copy keydown.enter->clipboard#copy keydown.space->clipboard#copy'
+
       def initialize(as: nil, value: nil, source_id: nil, success_text: 'Copied!',
                      tooltip: nil, tooltip_success: nil, tooltip_placement: 'top', **options)
         @as = as
@@ -16,14 +18,24 @@ module JetUi
       end
 
       def call
-        if @as
-          helpers.jet_ui.public_send(@as, **attrs) { content }
-        else
-          content_tag :span, content, class: classes, **attrs
-        end
+        return helpers.jet_ui.public_send(@as, **attrs) { content } if @as
+
+        default_trigger
       end
 
       private
+
+      def default_trigger
+        content_tag(
+          :span,
+          content,
+          role: :button,
+          tabindex: 0,
+          aria: { label: 'Copy to clipboard' },
+          class: classes,
+          **attrs
+        )
+      end
 
       def attrs
         @options.except(:class, :data).merge(data: data_attributes)
@@ -33,13 +45,19 @@ module JetUi
         base = {
           controller: @tooltip ? 'clipboard tooltip' : 'clipboard',
           clipboard_success_text_value: @success_text,
-          action: @tooltip ? 'click->clipboard#copy clipboard:change->tooltip#updateContent' : 'click->clipboard#copy'
+          action: actions
         }
 
         base[:clipboard_content_value] = @value if @value
         base[:clipboard_source_id_value] = @source_id if @source_id
         base.merge!(tooltip_attributes) if @tooltip
         base.merge(@options.fetch(:data, {}))
+      end
+
+      def actions
+        return COPY_ACTION unless @tooltip
+
+        "#{COPY_ACTION} clipboard:change->tooltip#updateContent"
       end
 
       def tooltip_attributes

--- a/app/components/jet_ui/drawer/component.rb
+++ b/app/components/jet_ui/drawer/component.rb
@@ -42,7 +42,11 @@ module JetUi
       end
 
       def dialog_tag(**options, &block)
-        attrs = { tabindex: '-1', class: class_names('drawer', 'animate-slide-left', "w-#{@size}") }
+        attrs = {
+          tabindex: '-1',
+          class: class_names('drawer', 'animate-slide-left', "w-#{@size}"),
+          aria: { label: @title || 'Drawer', modal: true }
+        }
         content_tag :dialog, **attrs, **options, &block
       end
 

--- a/app/components/jet_ui/dropdown/button_component.rb
+++ b/app/components/jet_ui/dropdown/button_component.rb
@@ -10,7 +10,7 @@ module JetUi
 
       erb_template <<~ERB
         <li class="dropdown__item">
-          <%= button_to content, @href, **@options.except(:class), class: classes, form: { class: "dropdown__form" } %>
+          <%= button_to content, @href, **@options.except(:class), class: classes, role: 'menuitem', form: { class: "dropdown__form" } %>
         </li>
       ERB
 

--- a/app/components/jet_ui/dropdown/link_component.rb
+++ b/app/components/jet_ui/dropdown/link_component.rb
@@ -11,7 +11,7 @@ module JetUi
 
       erb_template <<~ERB
         <li class="dropdown__item">
-          <%= link_to content, @url, class: classes, **@options.except(:class) %>
+          <%= link_to content, @url, class: classes, role: 'menuitem', **@options.except(:class) %>
         </li>
       ERB
 

--- a/app/components/jet_ui/dropdown/menu_component.rb
+++ b/app/components/jet_ui/dropdown/menu_component.rb
@@ -9,7 +9,7 @@ module JetUi
 
       erb_template <<~ERB
         <div class="dropdown__menu" data-dropdown-target="menu">
-          <ul class="<%= classes %>">
+          <ul class="<%= classes %>" role="menu">
             <%= content %>
           </ul>
         </div>

--- a/app/components/jet_ui/dropdown/trigger_component.rb
+++ b/app/components/jet_ui/dropdown/trigger_component.rb
@@ -6,19 +6,31 @@ module JetUi
       def initialize(as: nil, **options)
         @as = as
         @options = options
-        @options[:data] ||= {}
-        @options[:data][:dropdown_target] = 'trigger'
+        configure_accessibility
       end
 
       def call
         if @as
           helpers.jet_ui.public_send(@as, **@options) { content }
         else
-          content_tag :span, content, role: :button, class: classes, **@options.except(:class)
+          content_tag :span, content, role: :button, tabindex: 0, class: classes, **@options.except(:class)
         end
       end
 
       private
+
+      def configure_accessibility
+        @options[:data] ||= {}
+        @options[:aria] ||= {}
+        @options[:data][:dropdown_target] = 'trigger'
+        unless @as
+          @options[:data][:action] = [
+            @options[:data][:action],
+            'keydown.enter->dropdown#toggle keydown.space->dropdown#toggle'
+          ].compact.join(' ')
+        end
+        @options[:aria].reverse_merge!(haspopup: 'menu', expanded: false)
+      end
 
       def classes
         class_names('dropdown__trigger', @options[:class])

--- a/app/components/jet_ui/modal/component.rb
+++ b/app/components/jet_ui/modal/component.rb
@@ -42,7 +42,11 @@ module JetUi
       end
 
       def dialog_tag(**options, &block)
-        attrs = { tabindex: '-1', class: class_names('modal', 'animate-slide-up', "w-#{@size}") }
+        attrs = {
+          tabindex: '-1',
+          class: class_names('modal', 'animate-slide-up', "w-#{@size}"),
+          aria: { label: @title || 'Dialog', modal: true }
+        }
         content_tag :dialog, **attrs, **options, &block
       end
 

--- a/app/components/jet_ui/tooltip/component.rb
+++ b/app/components/jet_ui/tooltip/component.rb
@@ -14,7 +14,7 @@ module JetUi
         if @as
           helpers.jet_ui.public_send(@as, **attrs) { content }
         else
-          content_tag :span, content, class: 'w-fit', **attrs
+          content_tag :span, content, tabindex: 0, class: 'w-fit', **attrs
         end
       end
 

--- a/app/components/jet_ui/turbo_confirm/component.html.erb
+++ b/app/components/jet_ui/turbo_confirm/component.html.erb
@@ -1,15 +1,18 @@
 <dialog id="turbo-confirm" tabindex="-1"
         class="modal w-2xl animate-slide-up"
+        aria-modal="true"
+        aria-labelledby="turbo-confirm-title"
+        aria-describedby="turbo-confirm-description"
         data-controller="turbo-confirm">
   <form method="dialog">
     <div class="modal__header modal__header-bordered">
       <div>
-        <h3 class="modal__title">Are you absolutely sure?</h3>
+        <h3 id="turbo-confirm-title" class="modal__title">Are you absolutely sure?</h3>
       </div>
     </div>
 
     <div class="modal__body">
-      <p>This cannot be undone.</p>
+      <p id="turbo-confirm-description">This cannot be undone.</p>
     </div>
 
     <div class="modal__footer modal__footer-bordered flex flex-row gap-2 items-start justify-end">

--- a/test/components/jet_ui/clipboard/component_test.rb
+++ b/test/components/jet_ui/clipboard/component_test.rb
@@ -37,7 +37,7 @@ class JetUi::Clipboard::ComponentTest < ViewComponent::TestCase
   def test_has_copy_action
     render_inline(JetUi::Clipboard::Component.new(value: 'text')) { 'Copy' }
 
-    assert_selector '[data-action="click->clipboard#copy"]'
+    assert_selector '[data-action*="click->clipboard#copy"]'
   end
 
   def test_adds_tooltip_controller_when_tooltip_given
@@ -50,5 +50,13 @@ class JetUi::Clipboard::ComponentTest < ViewComponent::TestCase
     render_inline(JetUi::Clipboard::Component.new(value: 'text', class: 'extra')) { 'Copy' }
 
     assert_selector 'span.cursor-pointer.extra'
+  end
+
+  def test_default_trigger_supports_keyboard_copying
+    render_inline(JetUi::Clipboard::Component.new(value: 'text')) { 'Copy' }
+
+    assert_selector 'span[role="button"][tabindex="0"][aria-label="Copy to clipboard"]'
+    assert_selector '[data-action*="keydown.enter->clipboard#copy"]'
+    assert_selector '[data-action*="keydown.space->clipboard#copy"]'
   end
 end

--- a/test/components/jet_ui/drawer/component_test.rb
+++ b/test/components/jet_ui/drawer/component_test.rb
@@ -61,4 +61,10 @@ class JetUi::Drawer::ComponentTest < ViewComponent::TestCase
 
     assert_selector 'div.drawer__footer-bordered'
   end
+
+  def test_dialog_has_an_accessible_name_and_modal_state
+    render_inline(JetUi::Drawer::Component.new(id: 'my-drawer', title: 'Navigation'))
+
+    assert_selector 'dialog[aria-label="Navigation"][aria-modal="true"]'
+  end
 end

--- a/test/components/jet_ui/dropdown/component_test.rb
+++ b/test/components/jet_ui/dropdown/component_test.rb
@@ -66,4 +66,24 @@ class JetUi::Dropdown::ComponentTest < ViewComponent::TestCase
 
     assert_selector 'div.dropdown.extra'
   end
+
+  def test_trigger_supports_keyboard_activation
+    render_inline(JetUi::Dropdown::TriggerComponent.new) { 'Open' }
+
+    assert_selector 'span[tabindex="0"][aria-haspopup="menu"][aria-expanded="false"]'
+    assert_selector '[data-action*="keydown.enter->dropdown#toggle"]'
+    assert_selector '[data-action*="keydown.space->dropdown#toggle"]'
+  end
+
+  def test_menu_has_menu_role
+    render_inline(JetUi::Dropdown::MenuComponent.new)
+
+    assert_selector 'ul[role="menu"]'
+  end
+
+  def test_link_has_menuitem_role
+    render_inline(JetUi::Dropdown::LinkComponent.new(url: '/path')) { 'Link' }
+
+    assert_selector 'a[role="menuitem"]'
+  end
 end

--- a/test/components/jet_ui/dropdown/component_test.rb
+++ b/test/components/jet_ui/dropdown/component_test.rb
@@ -86,4 +86,10 @@ class JetUi::Dropdown::ComponentTest < ViewComponent::TestCase
 
     assert_selector 'a[role="menuitem"]'
   end
+
+  def test_button_has_menuitem_role
+    render_inline(JetUi::Dropdown::ButtonComponent.new(href: '/path')) { 'Action' }
+
+    assert_selector 'input[type="submit"][role="menuitem"]'
+  end
 end

--- a/test/components/jet_ui/modal/component_test.rb
+++ b/test/components/jet_ui/modal/component_test.rb
@@ -73,4 +73,10 @@ class JetUi::Modal::ComponentTest < ViewComponent::TestCase
 
     assert_selector 'div.justify-end'
   end
+
+  def test_dialog_has_an_accessible_name_and_modal_state
+    render_inline(JetUi::Modal::Component.new(id: 'my-modal', title: 'Edit profile'))
+
+    assert_selector 'dialog[aria-label="Edit profile"][aria-modal="true"]'
+  end
 end

--- a/test/components/jet_ui/tooltip/component_test.rb
+++ b/test/components/jet_ui/tooltip/component_test.rb
@@ -33,4 +33,10 @@ class JetUi::Tooltip::ComponentTest < ViewComponent::TestCase
 
     assert_selector '[data-tooltip-placement-value="right"]'
   end
+
+  def test_default_trigger_is_keyboard_focusable
+    render_inline(JetUi::Tooltip::Component.new(title: 'Tooltip text')) { 'Hover me' }
+
+    assert_selector 'span.w-fit[tabindex="0"]'
+  end
 end

--- a/test/components/jet_ui/turbo_confirm/component_test.rb
+++ b/test/components/jet_ui/turbo_confirm/component_test.rb
@@ -39,4 +39,12 @@ class JetUi::TurboConfirm::ComponentTest < ViewComponent::TestCase
 
     assert_selector 'dialog.modal'
   end
+
+  def test_has_accessible_dialog_metadata
+    render_inline(JetUi::TurboConfirm::Component.new)
+
+    assert_selector 'dialog[aria-modal="true"][aria-labelledby="turbo-confirm-title"][aria-describedby="turbo-confirm-description"]'
+    assert_selector '#turbo-confirm-title'
+    assert_selector '#turbo-confirm-description'
+  end
 end


### PR DESCRIPTION
## Summary
- add accessible names and modal semantics to dialogs and Turbo Confirm
- make default dropdown, tooltip, and clipboard triggers keyboard-accessible
- keep dropdown expanded state synchronized with its trigger and restore focus on Escape
- close modal and drawer controllers on native Escape cancellation

Closes #9

## Verification
- `bundle exec rake test` (395 runs, 535 assertions)
- `bundle exec rubocop` on changed Ruby files
- `node --check` on changed Stimulus controllers
- `git diff --check`

Browser-only keyboard and axe checks remain for reviewer validation.