### PR TITLE
feat(dialog): unify Modal and Drawer into a single Dialog component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Dialog` component — unifies `Modal` and `Drawer` into a single component built on the native `<dialog>` element, with five positions (`:center`, `:left`, `:right`, `:top`, `:bottom`) and unlimited nesting of stacked dialogs
+- `Dialogs` mount point component — renders the dialog stack root and the sentinel Turbo Frame that async dialog opens adopt
+
+### Deprecated
+- `Modal` and `Drawer` — now thin shims delegating to `Dialog` with `position: :center`/`:right`; emit an `ActiveSupport::Deprecation` warning and will be removed in the next major version. Existing `data: { turbo_frame: :modal }`/`:drawer` links keep working automatically. See [docs/components/dialog.md](docs/components/dialog.md#migrating-from-modaldrawer) for the full migration path
+
 ## [0.2.11] - 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ rails generate jet_ui:install
 Then register the controllers you use (`@hotwired/stimulus` is a peer dependency):
 
 ```javascript
-import { ModalController } from "@jetrockets/jet_ui"
+import { DialogController, DialogsController } from "@jetrockets/jet_ui"
 
-application.register("modal", ModalController)
+application.register("dialog", DialogController)
+application.register("dialogs", DialogsController)
 ```
 
 Import the component styles in your Tailwind/CSS entry point:
@@ -113,8 +114,9 @@ Subcomponents follow the `namespace_subcomponent` naming convention (`card_heade
 | Sidebar | [docs/components/sidebar.md](docs/components/sidebar.md) |
 | Header | [docs/components/header.md](docs/components/header.md) |
 | Navbar | [docs/components/navbar.md](docs/components/navbar.md) |
-| Modal ⚡ | [docs/components/modal.md](docs/components/modal.md) |
-| Drawer ⚡ | [docs/components/drawer.md](docs/components/drawer.md) |
+| Dialog ⚡ | [docs/components/dialog.md](docs/components/dialog.md) |
+| Modal ⚡ (deprecated, use Dialog) | [docs/components/modal.md](docs/components/modal.md) |
+| Drawer ⚡ (deprecated, use Dialog) | [docs/components/drawer.md](docs/components/drawer.md) |
 | Dropdown ⚡ | [docs/components/dropdown.md](docs/components/dropdown.md) |
 | Tooltip ⚡ | [docs/components/tooltip.md](docs/components/tooltip.md) |
 | Popover ⚡ | [docs/components/popover.md](docs/components/popover.md) |

--- a/app/assets/javascripts/jet_ui/dialog_controller.js
+++ b/app/assets/javascripts/jet_ui/dialog_controller.js
@@ -1,0 +1,95 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Per-dialog behaviour: backdrop click / swipe-to-dismiss / Esc handling for a single
+// <dialog>. Opening, stacking and DOM cleanup are owned by DialogsController — this
+// controller only reacts to interactions on an already-mounted dialog.
+export default class DialogController extends Controller {
+  static targets = ["panel"]
+
+  static values = {
+    position: { type: String, default: "center" },
+    dismissible: { type: Boolean, default: true },
+    swipe: { type: Boolean, default: false },
+    swipeThreshold: { type: Number, default: 100 }
+  }
+
+  #touchStart = 0
+
+  connect() {
+    this.element.addEventListener("click", this.#handleBackdropClick)
+    this.element.addEventListener("cancel", this.#handleCancel)
+
+    if (this.swipeValue) {
+      this.element.addEventListener("touchstart", this.#handleTouchStart, { passive: true })
+      this.element.addEventListener("touchmove", this.#handleTouchMove, { passive: true })
+      this.element.addEventListener("touchend", this.#handleTouchEnd, { passive: true })
+    }
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this.#handleBackdropClick)
+    this.element.removeEventListener("cancel", this.#handleCancel)
+    this.element.removeEventListener("touchstart", this.#handleTouchStart)
+    this.element.removeEventListener("touchmove", this.#handleTouchMove)
+    this.element.removeEventListener("touchend", this.#handleTouchEnd)
+  }
+
+  close() {
+    try {
+      this.element.close()
+    } catch (e) {}
+  }
+
+  #handleBackdropClick = (event) => {
+    if (event.target === this.element && this.dismissibleValue) {
+      this.close()
+    }
+  }
+
+  #handleCancel = (event) => {
+    if (!this.dismissibleValue) event.preventDefault()
+  }
+
+  #axis() {
+    return this.positionValue === "top" || this.positionValue === "bottom" ? "y" : "x"
+  }
+
+  // Sign of the direction that counts as "swiping the panel away".
+  #sign() {
+    return { left: -1, right: 1, top: -1, bottom: 1 }[this.positionValue] ?? 1
+  }
+
+  #coordinate(touch) {
+    return this.#axis() === "x" ? touch.clientX : touch.clientY
+  }
+
+  #translate(value, unit) {
+    return this.#axis() === "x" ? `translateX(${value}${unit})` : `translateY(${value}${unit})`
+  }
+
+  #handleTouchStart = (event) => {
+    if (!this.hasPanelTarget) return
+    this.#touchStart = this.#coordinate(event.touches[0])
+    this.panelTarget.style.transition = "none"
+  }
+
+  #handleTouchMove = (event) => {
+    if (!this.hasPanelTarget) return
+    const delta = (this.#coordinate(event.touches[0]) - this.#touchStart) * this.#sign()
+    const clamped = Math.max(0, delta)
+    this.panelTarget.style.transform = this.#translate(clamped * this.#sign(), "px")
+  }
+
+  #handleTouchEnd = (event) => {
+    if (!this.hasPanelTarget) return
+    const delta = (this.#coordinate(event.changedTouches[0]) - this.#touchStart) * this.#sign()
+    this.panelTarget.style.transition = "transform 0.2s ease-out"
+
+    if (delta > this.swipeThresholdValue) {
+      this.panelTarget.style.transform = this.#translate(this.#sign() * 100, "%")
+      this.panelTarget.addEventListener("transitionend", () => this.close(), { once: true })
+    } else {
+      this.panelTarget.style.transform = this.#translate(0, "px")
+    }
+  }
+}

--- a/app/assets/javascripts/jet_ui/dialogs_controller.js
+++ b/app/assets/javascripts/jet_ui/dialogs_controller.js
@@ -82,7 +82,13 @@ export default class DialogsController extends Controller {
     // Deprecated aliases ("modal"/"drawer") point at a frame id that no longer exists in the
     // DOM — only the "dialog" sentinel does. Rewrite the trigger before Turbo reads it (we run
     // first, same capture phase) so its own getElementById(frameName) lookup still finds it.
-    if (frameName !== FRAME_ID) this.#rewriteFrameName(event, trigger)
+    // Persist the resolved position on the trigger too: once data-turbo-frame becomes "dialog"
+    // it no longer carries the alias, so without this a second click on the same trigger would
+    // resolve to the "dialog" default position instead of the alias's preset.
+    if (frameName !== FRAME_ID) {
+      this.#rewriteFrameName(event, trigger)
+      if (trigger && !trigger.dataset.dialogPosition) trigger.dataset.dialogPosition = position
+    }
 
     sentinel.dataset.pending = "true"
 

--- a/app/assets/javascripts/jet_ui/dialogs_controller.js
+++ b/app/assets/javascripts/jet_ui/dialogs_controller.js
@@ -1,0 +1,242 @@
+import { Controller } from "@hotwired/stimulus"
+
+const FRAME_ID = "dialog"
+const DEFAULT_POSITION = "center"
+const DEFAULT_SIZE = "2xl"
+const HORIZONTAL_POSITIONS = ["top", "bottom"]
+
+// Legacy `data-turbo-frame` values kept working after the Modal/Drawer → Dialog unification.
+// Each alias presets a position and is rewritten to the real frame id ("dialog") before Turbo
+// resolves it, so existing async links need no edits — see docs/components/dialog.md.
+const FRAME_ALIASES = {
+  dialog: DEFAULT_POSITION,
+  modal: "center",
+  drawer: "right"
+}
+
+// Stack manager for every <dialog> on the page — sync (declared inline with an `id`) and
+// remote (opened via a link/form with data-turbo-frame="dialog", or the deprecated "modal"/
+// "drawer" aliases). Unlimited nesting works because the manager, not any single dialog, owns
+// depth tracking, the flash portal and the "sentinel" <turbo-frame id="dialog"> that every
+// async open adopts.
+export default class DialogsController extends Controller {
+  static targets = ["root", "sentinel", "dialog"]
+
+  #stack = []
+  #frameCounter = 0
+
+  connect() {
+    window.addEventListener("click", this.#interceptTrigger, { capture: true })
+    window.addEventListener("submit", this.#interceptTrigger, { capture: true })
+    document.addEventListener("turbo:frame-load", this.#handleFrameLoad)
+    document.addEventListener("turbo:frame-missing", this.#handleFrameMissing)
+    document.addEventListener("turbo:fetch-request-error", this.#handleFrameMissing)
+    document.addEventListener("turbo:before-visit", this.closeAll)
+    document.addEventListener("turbo:before-cache", this.closeAll)
+    document.addEventListener("turbo:before-render", this.#handleBeforeRender)
+    document.addEventListener("turbo:render", this.#handleRender)
+  }
+
+  disconnect() {
+    window.removeEventListener("click", this.#interceptTrigger, { capture: true })
+    window.removeEventListener("submit", this.#interceptTrigger, { capture: true })
+    document.removeEventListener("turbo:frame-load", this.#handleFrameLoad)
+    document.removeEventListener("turbo:frame-missing", this.#handleFrameMissing)
+    document.removeEventListener("turbo:fetch-request-error", this.#handleFrameMissing)
+    document.removeEventListener("turbo:before-visit", this.closeAll)
+    document.removeEventListener("turbo:before-cache", this.closeAll)
+    document.removeEventListener("turbo:before-render", this.#handleBeforeRender)
+    document.removeEventListener("turbo:render", this.#handleRender)
+  }
+
+  // Sync open — data-action="click->dialogs#open" data-id="myDialog" on the trigger.
+  open(event) {
+    const id = event.currentTarget.dataset.id
+    const dialog = this.dialogTargets.find((d) => d.id === id)
+    if (!dialog || this.#stack.includes(dialog)) return
+
+    this.#push(dialog, { remote: false })
+  }
+
+  closeAll = () => {
+    // Copy first: closing dispatches 'close' synchronously, which mutates #stack.
+    ;[...this.#stack].reverse().forEach((dialog) => dialog.close())
+  }
+
+  // --- async open: adopt the sentinel frame before Turbo navigates it ---------------------
+
+  #interceptTrigger = (event) => {
+    const frameName = this.#resolveFrameName(event)
+    if (!(frameName in FRAME_ALIASES)) return
+    if (!this.hasSentinelTarget) return
+    if (this.#opensInNewTab(event)) return
+
+    const sentinel = this.sentinelTarget
+    if (sentinel.dataset.pending === "true") return // already adopted, let Turbo re-navigate it
+
+    const trigger = this.#resolveTrigger(event)
+    const position = trigger?.dataset.dialogPosition || FRAME_ALIASES[frameName]
+    const size = trigger?.dataset.dialogSize || DEFAULT_SIZE
+    const dismissible = trigger?.dataset.dialogDismissible !== "false"
+
+    // Deprecated aliases ("modal"/"drawer") point at a frame id that no longer exists in the
+    // DOM — only the "dialog" sentinel does. Rewrite the trigger before Turbo reads it (we run
+    // first, same capture phase) so its own getElementById(frameName) lookup still finds it.
+    if (frameName !== FRAME_ID) this.#rewriteFrameName(event, trigger)
+
+    sentinel.dataset.pending = "true"
+
+    const shell = this.#buildShell({ position, size, dismissible })
+    shell.append(sentinel)
+    this.rootTarget.append(shell)
+
+    this.#push(shell, { remote: true })
+  }
+
+  // A modified click (Cmd/Ctrl/Shift/Alt, middle-click) or a link with target/download makes
+  // the browser open a new tab/window instead of navigating in place — Turbo itself ignores
+  // these clicks and lets the browser handle them, so we must too, or we'd adopt the sentinel
+  // and show an overlay for a navigation that never actually happens on this page.
+  #opensInNewTab(event) {
+    if (event.type !== "click") return false
+    if (event.button !== 0) return true
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return true
+
+    const trigger = this.#resolveTrigger(event)
+    const target = trigger?.getAttribute?.("target")
+    if (target && target !== "_self") return true
+
+    return trigger?.hasAttribute?.("download") ?? false
+  }
+
+  #resolveFrameName(event) {
+    if (event.type === "submit") {
+      const form = event.target
+      return event.submitter?.dataset.turboFrame || form?.dataset.turboFrame || null
+    }
+
+    const trigger = event.target?.closest?.("[data-turbo-frame]")
+    return trigger?.dataset.turboFrame || null
+  }
+
+  #resolveTrigger(event) {
+    if (event.type === "submit") {
+      return event.submitter?.dataset.turboFrame ? event.submitter : event.target
+    }
+
+    return event.target?.closest?.("[data-turbo-frame]") || null
+  }
+
+  #rewriteFrameName(event, trigger) {
+    if (!trigger) return
+    trigger.dataset.turboFrame = FRAME_ID
+  }
+
+  #buildShell({ position, size, dismissible }) {
+    const horizontal = HORIZONTAL_POSITIONS.includes(position)
+    const edge = position !== DEFAULT_POSITION
+
+    const dialog = document.createElement("dialog")
+    dialog.tabIndex = -1
+    dialog.className = `dialog dialog-${position} ${horizontal ? "h" : "w"}-${size}`
+    dialog.dataset.controller = "dialog"
+    dialog.dataset.dialogPositionValue = position
+    dialog.dataset.dialogDismissibleValue = String(dismissible)
+    dialog.dataset.dialogSwipeValue = String(edge)
+    return dialog
+  }
+
+  #handleFrameLoad = (event) => {
+    const frame = event.target
+    if (frame?.tagName !== "TURBO-FRAME") return
+    if (frame.id !== FRAME_ID) return
+
+    delete frame.dataset.pending
+    delete frame.dataset.dialogsTarget
+    frame.id = `${FRAME_ID}-${++this.#frameCounter}`
+
+    this.#respawnSentinel()
+    this.#portalFlash()
+  }
+
+  #handleFrameMissing = (event) => {
+    const frame = event.target
+    if (frame?.tagName !== "TURBO-FRAME") return
+    if (!new RegExp(`^${FRAME_ID}(-\\d+)?$`).test(frame.id)) return
+
+    const shell = frame.closest("dialog.dialog")
+    if (!shell) return
+
+    if (frame.id === FRAME_ID) this.#respawnSentinel()
+    shell.close()
+  }
+
+  #respawnSentinel() {
+    const sentinel = document.createElement("turbo-frame")
+    sentinel.id = FRAME_ID
+    sentinel.dataset.dialogsTarget = "sentinel"
+    this.rootTarget.append(sentinel)
+  }
+
+  // --- stack bookkeeping -------------------------------------------------------------------
+
+  #push(dialog, { remote }) {
+    dialog.dataset.remote = String(remote)
+    this.#stack.push(dialog)
+    this.#renumber()
+
+    dialog.addEventListener("close", this.#handleDialogClosed, { once: true })
+    dialog.showModal()
+
+    this.#portalFlash()
+    dialog.dispatchEvent(new CustomEvent("jet-ui:dialog:opened", {
+      bubbles: true,
+      detail: { depth: this.#stack.indexOf(dialog), position: dialog.dataset.dialogPositionValue }
+    }))
+  }
+
+  #handleDialogClosed = (event) => {
+    const dialog = event.target
+    const index = this.#stack.indexOf(dialog)
+    if (index === -1) return
+
+    this.#stack.splice(index, 1)
+    this.#renumber()
+
+    dialog.dispatchEvent(new CustomEvent("jet-ui:dialog:closed", { bubbles: true }))
+
+    if (dialog.dataset.remote === "true") dialog.remove()
+
+    this.#portalFlash()
+  }
+
+  #renumber() {
+    this.#stack.forEach((dialog, index) => { dialog.dataset.depth = String(index) })
+  }
+
+  // --- flash portal --------------------------------------------------------------------------
+  // The topmost open dialog is promoted to the browser's top layer, which makes everything
+  // outside it inert — a flash frame left in <body> would be invisible and unclickable.
+  // We move #flash into the topmost dialog's .dialog__flash-slot instead (see dialog.css).
+
+  #portalFlash = () => {
+    const flashFrame = document.getElementById("flash")
+    if (!flashFrame) return
+
+    const top = this.#stack.at(-1)
+    const target = top ? top.querySelector(".dialog__flash-slot") : document.body
+    if (target && flashFrame.parentElement !== target) target.append(flashFrame)
+  }
+
+  // #dialogs is data-turbo-permanent so open dialogs survive a morph refresh — but that also
+  // means Turbo won't merge a fresh #flash into a copy that is currently portaled inside it.
+  // Pull it back out to <body> before every render, then re-portal it after.
+  #handleBeforeRender = () => {
+    const flashFrame = document.getElementById("flash")
+    if (flashFrame && flashFrame.parentElement !== document.body) document.body.append(flashFrame)
+  }
+
+  #handleRender = () => {
+    this.#portalFlash()
+  }
+}

--- a/app/assets/javascripts/jet_ui/drawer_controller.js
+++ b/app/assets/javascripts/jet_ui/drawer_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
+// @deprecated Only the async (Turbo Frame) dialog markup rendered by JetUi::Dialog::Component
+// still uses "modal"/"drawer" as data-turbo-frame aliases — those keep working automatically,
+// handled by DialogsController. This standalone controller matches the pre-Dialog async drawer
+// markup and is no longer wired up by JetUi::Drawer::Component. Kept only for apps with custom
+// markup still registering it directly. Migrate to the "dialog" controller. Removed in the
+// next major version.
 export default class DrawerController extends Controller {
   static values = {
     swipeThreshold: { type: Number, default: 100 }

--- a/app/assets/javascripts/jet_ui/drawers_controller.js
+++ b/app/assets/javascripts/jet_ui/drawers_controller.js
@@ -1,5 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
+// @deprecated JetUi::Drawer::Component's sync-mode markup now targets
+// data-dialogs-target="dialog" (see JetUi::Dialog::Component), not
+// data-drawers-target="dialog" — this controller no longer matches it. Migrate your
+// data-controller="drawers" wrapper and click->drawers#open actions to "dialogs" /
+// click->dialogs#open. Removed in the next major version.
 export default class DrawersController extends Controller {
   static targets = ["dialog"]
   static values = {

--- a/app/assets/javascripts/jet_ui/modal_controller.js
+++ b/app/assets/javascripts/jet_ui/modal_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
+// @deprecated Only the async (Turbo Frame) dialog markup rendered by JetUi::Dialog::Component
+// still uses "modal"/"drawer" as data-turbo-frame aliases — those keep working automatically,
+// handled by DialogsController. This standalone controller matches the pre-Dialog async modal
+// markup and is no longer wired up by JetUi::Modal::Component. Kept only for apps with custom
+// markup still registering it directly. Migrate to the "dialog" controller. Removed in the
+// next major version.
 export default class ModalController extends Controller {
   connect() {
     this.element.addEventListener("click", this.#closeOnBackdropClick.bind(this))

--- a/app/assets/javascripts/jet_ui/modals_controller.js
+++ b/app/assets/javascripts/jet_ui/modals_controller.js
@@ -1,5 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
+// @deprecated JetUi::Modal::Component's sync-mode markup now targets
+// data-dialogs-target="dialog" (see JetUi::Dialog::Component), not
+// data-modals-target="dialog" — this controller no longer matches it. Migrate your
+// data-controller="modals" wrapper and click->modals#open actions to "dialogs" /
+// click->dialogs#open. Removed in the next major version.
 export default class ModalsController extends Controller {
   static targets = ["dialog"]
 

--- a/app/assets/stylesheets/jet_ui.css
+++ b/app/assets/stylesheets/jet_ui.css
@@ -21,6 +21,7 @@
 @import "./jet_ui/sidebar.css";
 @import "./jet_ui/header.css";
 @import "./jet_ui/navbar.css";
+@import "./jet_ui/dialog.css";
 @import "./jet_ui/modal.css";
 @import "./jet_ui/drawer.css";
 @import "./jet_ui/dropdown.css";

--- a/app/assets/stylesheets/jet_ui/dialog.css
+++ b/app/assets/stylesheets/jet_ui/dialog.css
@@ -1,0 +1,134 @@
+@layer theme, base, components, utilities;
+
+@layer components {
+  /*
+   * .dialog is a pure, invisible positioning shell: fixed, sized, anchored to an edge (or
+   * centered). It must never carry a background, shadow, rounded corners, overflow-hidden, or
+   * — most importantly — transform/filter/perspective/contain/will-change, because any of
+   * those would make it a containing block for position: fixed descendants, breaking the
+   * flash portal (see dialogs_controller.js's #portalFlash — .dialog__flash-slot is a sibling
+   * of .dialog__panel for exactly this reason, not a descendant of it).
+   *
+   * All visible chrome (background, shadow, rounded corners, clipping) and the enter animation
+   * live on .dialog__panel instead, so the whole visible card animates as one piece instead of
+   * the chrome popping in instantly while only the content inside it slides/fades.
+   */
+  .dialog {
+    @apply fixed hidden p-0 m-0 border-0 bg-transparent;
+    @apply animate-slide-up;
+  }
+
+  .dialog[open] {
+    @apply flex flex-col;
+  }
+
+  .dialog::backdrop {
+    @apply bg-overlay;
+  }
+
+  .dialog-center {
+    @apply inset-0 m-auto h-fit min-h-24 max-w-11/12 max-h-11/12;
+  }
+
+  .dialog-left {
+    @apply animate-slide-right;
+    @apply inset-y-0 left-0 right-auto h-full max-h-full;
+    max-width: min(90%, 1280px);
+  }
+
+  .dialog-right {
+    @apply animate-slide-left;
+    @apply inset-y-0 left-auto right-0 h-full max-h-full;
+    max-width: min(90%, 1280px);
+  }
+
+  .dialog-top {
+    @apply animate-slide-down;
+    @apply inset-x-0 bottom-auto top-0 w-full max-h-11/12 max-w-full;
+  }
+
+  .dialog-bottom {
+    @apply animate-slide-up;
+    @apply inset-x-0 bottom-0 top-auto w-full max-h-11/12 max-w-full;
+  }
+
+  /*
+   * A remote dialog's content arrives inside a <turbo-frame id="dialog">, which sits between
+   * .dialog and its children — make it transparent to layout so .dialog__panel and
+   * .dialog__flash-slot still behave as .dialog's direct flex children.
+   */
+  .dialog > turbo-frame {
+    display: contents;
+  }
+
+  .dialog__panel {
+    @apply relative flex flex-col flex-1 overflow-hidden;
+    @apply shadow-sm bg-card rounded-modal;
+  }
+
+  .dialog-left .dialog__panel {
+    @apply rounded-l-none;
+  }
+
+  .dialog-right .dialog__panel {
+    @apply rounded-r-none;
+  }
+
+  .dialog-top .dialog__panel {
+    @apply rounded-t-none;
+  }
+
+  .dialog-bottom .dialog__panel {
+    @apply rounded-b-none;
+  }
+
+  .dialog__header {
+    @apply flex items-start justify-between flex-shrink-0 p-4 px-6 backdrop-blur-sm bg-card/70;
+  }
+
+  .dialog__header-bordered {
+    @apply border-b border-border;
+  }
+
+  .dialog__title {
+    @apply text-xl font-semibold leading-tight text-foreground;
+  }
+
+  .dialog__subtitle {
+    @apply mt-1 text-sm text-muted-foreground;
+  }
+
+  .dialog__close {
+    @apply inline-flex items-center p-1 ml-auto text-sm transition-all duration-300 bg-transparent rounded-full cursor-pointer outline-0;
+    @apply text-muted-foreground hover:bg-accent hover:text-accent-foreground;
+  }
+
+  .dialog__body {
+    @apply flex-1 min-h-0 px-6 py-6 overflow-auto;
+  }
+
+  .dialog__footer {
+    @apply flex-shrink-0 w-full p-4 backdrop-blur-sm bg-card/70;
+  }
+
+  .dialog__footer-bordered {
+    @apply border-t border-border;
+  }
+
+  /*
+   * Zero-size anchor the flash frame is portaled into (see dialogs_controller.js) so it is
+   * painted inside the topmost dialog's top-layer subtree. Deliberately a *sibling* of
+   * .dialog__panel, not nested inside it — .dialog__panel carries the enter animation
+   * (transform), which would otherwise turn it into a containing block for the portaled
+   * flash frame's position: fixed. display:contents keeps this slot itself out of the
+   * flex flow entirely.
+   */
+  .dialog__flash-slot {
+    display: contents;
+  }
+
+  /* Direct (non-Turbo-Frame, non-dialog) page render — e.g. a dialog URL visited directly. */
+  .dialog-page {
+    @apply mt-4 mx-auto;
+  }
+}

--- a/app/assets/stylesheets/jet_ui/theme.css
+++ b/app/assets/stylesheets/jet_ui/theme.css
@@ -13,6 +13,16 @@
     from { opacity: 0.8; transform: translateX(3rem); }
     to   { opacity: 1;   transform: translateX(0); }
   }
+
+  @keyframes slideRight {
+    from { opacity: 0.8; transform: translateX(-3rem); }
+    to   { opacity: 1;   transform: translateX(0); }
+  }
+
+  @keyframes slideDown {
+    from { opacity: 0.7; transform: translateY(-2rem); }
+    to   { opacity: 1;   transform: translateY(0); }
+  }
 }
 
 :root {
@@ -33,6 +43,8 @@
   --animate-fade-in: fadeIn 0.15s ease-in-out;
   --animate-slide-up: slideUp 0.3s ease-in-out;
   --animate-slide-left: slideLeft 0.3s ease-in-out;
+  --animate-slide-right: slideRight 0.3s ease-in-out;
+  --animate-slide-down: slideDown 0.3s ease-in-out;
 
   /* Radius */
   --radius-btn-xs: calc(var(--radius-md) * 0.75);

--- a/app/components/jet_ui/dialog/body_component.rb
+++ b/app/components/jet_ui/dialog/body_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dialog
+    class BodyComponent < JetUi::BaseComponent
+      def initialize(**options)
+        @options = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names('dialog__body', @options[:class])
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dialog/component.rb
+++ b/app/components/jet_ui/dialog/component.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dialog
+    class Component < JetUi::BaseComponent
+      SIZES = %w[sm md lg xl 2xl 3xl 4xl 5xl 6xl].freeze
+      DEFAULT_SIZE = '2xl'
+
+      POSITIONS = %i[center left right top bottom].freeze
+      DEFAULT_POSITION = :center
+
+      EDGE_POSITIONS = %i[left right top bottom].freeze
+
+      def initialize(title: nil, subtitle: nil, position: DEFAULT_POSITION, size: DEFAULT_SIZE,
+                     id: nil, closable: true, dismissible: true, swipe: true)
+        @title       = title
+        @subtitle    = subtitle
+        @position    = position.to_sym
+        @size        = size.to_s
+        @id          = id
+        @closable    = closable
+        @dismissible = dismissible
+        @swipe       = swipe && edge_position?
+      end
+
+      erb_template <<~ERB
+        <%= container_tag do %>
+          <div class="dialog__panel" data-dialog-target="panel">
+            <%= helpers.jet_ui.dialog_header(title: @title, subtitle: @subtitle, closable: closable?) %>
+            <%= content %>
+            <div class="dialog__flash-slot"></div>
+          </div>
+        <% end %>
+      ERB
+
+      private
+
+      def edge_position?
+        EDGE_POSITIONS.include?(@position)
+      end
+
+      def container_tag(&block)
+        # If @id is provided, we assume it's a sync dialog defined inline on the page.
+        return dialog_tag(id: @id, data: { dialogs_target: 'dialog' }, &block) if @id
+
+        # Async open (e.g. opened via a link with data: { turbo_frame: :dialog }).
+        # The <dialog> shell around this frame is created client-side by DialogsController
+        # before Turbo navigates the frame — see app/assets/javascripts/jet_ui/dialogs_controller.js.
+        return helpers.turbo_frame_tag(:dialog, &block) if helpers.turbo_frame_request?
+
+        # Not a Turbo Frame request (direct visit, new tab) — render as a plain page section.
+        content_tag :div, class: class_names('dialog-page', size_class), &block
+      end
+
+      def dialog_tag(**options, &block)
+        content_tag :dialog, tabindex: '-1', class: dialog_classes, data: dialog_data(options.delete(:data)),
+                             **options, &block
+      end
+
+      def dialog_classes
+        class_names('dialog', "dialog-#{@position}", size_class)
+      end
+
+      def dialog_data(extra)
+        {
+          controller: 'dialog',
+          dialog_position_value: @position,
+          dialog_dismissible_value: @dismissible,
+          dialog_swipe_value: @swipe
+        }.merge(extra || {})
+      end
+
+      def size_class
+        horizontal_edge? ? "h-#{@size}" : "w-#{@size}"
+      end
+
+      def horizontal_edge?
+        %i[top bottom].include?(@position)
+      end
+
+      def closable?
+        @closable && (helpers.turbo_frame_request? || @id)
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dialog/footer_component.rb
+++ b/app/components/jet_ui/dialog/footer_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dialog
+    class FooterComponent < JetUi::BaseComponent
+      def initialize(direction: :row, align: :start, justify: :start, bordered: true, **options)
+        @direction = direction
+        @align     = align
+        @justify   = justify
+        @bordered  = bordered
+        @options   = options
+      end
+
+      def call
+        content_tag :div, content, class: classes, **@options.except(:class)
+      end
+
+      private
+
+      def classes
+        class_names(
+          'dialog__footer',
+          { 'dialog__footer-bordered' => @bordered },
+          direction_class,
+          align_class,
+          justify_class,
+          @options[:class]
+        )
+      end
+
+      def direction_class
+        { col: 'flex flex-col gap-2', row: 'flex flex-row gap-2' }[@direction]
+      end
+
+      def align_class
+        { start: 'items-start', center: 'items-center', end: 'items-end' }[@align]
+      end
+
+      def justify_class
+        { start: 'justify-start', center: 'justify-center', end: 'justify-end',
+          between: 'justify-between' }[@justify]
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dialog/header_component.rb
+++ b/app/components/jet_ui/dialog/header_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dialog
+    class HeaderComponent < JetUi::BaseComponent
+      def initialize(title: nil, subtitle: nil, closable: true, bordered: true, **options)
+        @title    = title
+        @subtitle = subtitle
+        @closable = closable
+        @bordered = bordered
+        @options  = options
+      end
+
+      erb_template <<~ERB
+        <div class="<%= classes %>">
+          <div>
+            <% if @title %>
+              <h3 class="dialog__title"><%= @title %></h3>
+            <% end %>
+            <% if @subtitle %>
+              <div class="dialog__subtitle"><%= @subtitle %></div>
+            <% end %>
+            <%= content %>
+          </div>
+
+          <% if @closable %>
+            <button type="button" class="dialog__close" data-action="click->dialog#close" aria-label="Close">
+              <%= helpers.jet_ui.icon('x-mark', size: 6) %>
+            </button>
+          <% end %>
+        </div>
+      ERB
+
+      private
+
+      def classes
+        class_names(
+          'dialog__header',
+          { 'dialog__header-bordered' => @bordered },
+          @options[:class]
+        )
+      end
+    end
+  end
+end

--- a/app/components/jet_ui/dialogs/component.rb
+++ b/app/components/jet_ui/dialogs/component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module JetUi
+  module Dialogs
+    # Mount point for the dialog stack. Renders the `#dialogs` root that DialogsController
+    # manages (see app/assets/javascripts/jet_ui/dialogs_controller.js) plus the sentinel
+    # <turbo-frame id="dialog"> that every async dialog open (data: { turbo_frame: :dialog })
+    # adopts into a freshly built <dialog> shell before Turbo navigates it. Render this once
+    # in the host application's layout.
+    class Component < JetUi::BaseComponent
+      erb_template <<~ERB
+        <div id="dialogs" data-dialogs-target="root" data-turbo-permanent data-turbo-cache="false">
+          <%= helpers.turbo_frame_tag :dialog, data: { dialogs_target: 'sentinel' } %>
+        </div>
+      ERB
+    end
+  end
+end

--- a/app/components/jet_ui/drawer/body_component.rb
+++ b/app/components/jet_ui/drawer/body_component.rb
@@ -2,20 +2,8 @@
 
 module JetUi
   module Drawer
-    class BodyComponent < JetUi::BaseComponent
-      def initialize(**options)
-        @options = options
-      end
-
-      def call
-        content_tag :div, content, class: classes, **@options.except(:class)
-      end
-
-      private
-
-      def classes
-        class_names('drawer__body', @options[:class])
-      end
+    # @deprecated Use {JetUi::Dialog::BodyComponent} instead.
+    class BodyComponent < JetUi::Dialog::BodyComponent
     end
   end
 end

--- a/app/components/jet_ui/drawer/component.rb
+++ b/app/components/jet_ui/drawer/component.rb
@@ -2,52 +2,22 @@
 
 module JetUi
   module Drawer
-    class Component < JetUi::BaseComponent
-      SIZES = %w[sm md lg xl 2xl 3xl 4xl 5xl 6xl].freeze
-      DEFAULT_SIZE = '2xl'
-
-      def initialize(title: nil, subtitle: nil, size: DEFAULT_SIZE, id: nil)
-        @title = title
-        @subtitle = subtitle
-        @size = size
-        @id = id
+    # @deprecated Use {JetUi::Dialog::Component} with `position: :right` instead.
+    #   Kept as a thin shim so existing `jet_ui.drawer(...)` calls and
+    #   `data: { turbo_frame: :drawer }` links keep working. Will be removed in the next
+    #   major version.
+    class Component < JetUi::Dialog::Component
+      def self.deprecator
+        @deprecator ||= ActiveSupport::Deprecation.new('1.0', 'JetUi')
       end
 
-      erb_template <<~ERB
-        <%= container_tag do %>
-          <%= helpers.jet_ui.drawer_header(title: @title, subtitle: @subtitle, closable: closable?, id: @id) %>
-          <%= content %>
-        <% end %>
-      ERB
-
-      private
-
-      def container_tag(&block)
-        return sync_dialog(&block) if @id
-        return turbo_frame_dialog(&block) if helpers.turbo_frame_request?
-
-        content_tag :div, class: class_names('mx-auto bg-background', "w-#{@size}"), &block
-      end
-
-      def sync_dialog(&block)
-        dialog_tag(id: @id, data: { drawers_target: 'dialog' }, &block)
-      end
-
-      def turbo_frame_dialog(&block)
-        helpers.turbo_frame_tag :drawer do
-          dialog_tag(id: :drawerDialog, data: { controller: 'drawer' }) do
-            helpers.turbo_frame_tag(:drawerContent, &block)
-          end
-        end
-      end
-
-      def dialog_tag(**options, &block)
-        attrs = { tabindex: '-1', class: class_names('drawer', 'animate-slide-left', "w-#{@size}") }
-        content_tag :dialog, **attrs, **options, &block
-      end
-
-      def closable?
-        helpers.turbo_frame_request? || @id
+      def initialize(title: nil, subtitle: nil, size: JetUi::Dialog::Component::DEFAULT_SIZE, id: nil)
+        self.class.deprecator.warn(
+          'JetUi::Drawer::Component is deprecated and will be removed in the next major ' \
+          'version. Use JetUi::Dialog::Component with position: :right instead ' \
+          '(jet_ui.dialog).'
+        )
+        super(title: title, subtitle: subtitle, position: :right, size: size, id: id)
       end
     end
   end

--- a/app/components/jet_ui/drawer/footer_component.rb
+++ b/app/components/jet_ui/drawer/footer_component.rb
@@ -2,44 +2,8 @@
 
 module JetUi
   module Drawer
-    class FooterComponent < JetUi::BaseComponent
-      def initialize(direction: :row, align: :start, justify: :start, bordered: true, **options)
-        @direction = direction
-        @align = align
-        @justify = justify
-        @bordered = bordered
-        @options = options
-      end
-
-      def call
-        content_tag :div, content, class: classes, **@options.except(:class)
-      end
-
-      private
-
-      def classes
-        class_names(
-          'drawer__footer',
-          { 'drawer__footer-bordered' => @bordered },
-          direction_class,
-          align_class,
-          justify_class,
-          @options[:class]
-        )
-      end
-
-      def direction_class
-        { col: 'flex flex-col gap-2', row: 'flex flex-row gap-2' }[@direction]
-      end
-
-      def align_class
-        { start: 'items-start', center: 'items-center', end: 'items-end' }[@align]
-      end
-
-      def justify_class
-        { start: 'justify-start', center: 'justify-center', end: 'justify-end',
-          between: 'justify-between' }[@justify]
-      end
+    # @deprecated Use {JetUi::Dialog::FooterComponent} instead.
+    class FooterComponent < JetUi::Dialog::FooterComponent
     end
   end
 end

--- a/app/components/jet_ui/drawer/header_component.rb
+++ b/app/components/jet_ui/drawer/header_component.rb
@@ -2,44 +2,12 @@
 
 module JetUi
   module Drawer
-    class HeaderComponent < JetUi::BaseComponent
-      def initialize(title: nil, subtitle: nil, closable: true, id: nil, bordered: true, **options)
-        @title = title
-        @subtitle = subtitle
-        @closable = closable
-        @id = id
-        @bordered = bordered
-        @options = options
-      end
-
-      erb_template <<~ERB
-        <div class="<%= classes %>">
-          <div>
-            <% if @title %>
-              <h3 class="drawer__title"><%= @title %></h3>
-            <% end %>
-            <% if @subtitle %>
-              <div class="drawer__subtitle"><%= @subtitle %></div>
-            <% end %>
-            <%= content %>
-          </div>
-
-          <% if @closable %>
-            <button type="button" class="drawer__close" data-action="click->drawer#close click->drawers#close" aria-label="Close" data-id="<%= @id %>">
-              <%= helpers.jet_ui.icon("x-mark", size: 6) %>
-            </button>
-          <% end %>
-        </div>
-      ERB
-
-      private
-
-      def classes
-        class_names(
-          'drawer__header',
-          { 'drawer__header-bordered' => @bordered },
-          @options[:class]
-        )
+    # @deprecated Use {JetUi::Dialog::HeaderComponent} instead.
+    class HeaderComponent < JetUi::Dialog::HeaderComponent
+      # `id:` accepted and ignored for signature compatibility with the pre-deprecation API.
+      def initialize(title: nil, subtitle: nil, closable: true, id: nil, bordered: true, # rubocop:disable Lint/UnusedMethodArgument
+                     **options)
+        super(title: title, subtitle: subtitle, closable: closable, bordered: bordered, **options)
       end
     end
   end

--- a/app/components/jet_ui/modal/body_component.rb
+++ b/app/components/jet_ui/modal/body_component.rb
@@ -2,20 +2,8 @@
 
 module JetUi
   module Modal
-    class BodyComponent < JetUi::BaseComponent
-      def initialize(**options)
-        @options = options
-      end
-
-      def call
-        content_tag :div, content, class: classes, **@options.except(:class)
-      end
-
-      private
-
-      def classes
-        class_names('modal__body', @options[:class])
-      end
+    # @deprecated Use {JetUi::Dialog::BodyComponent} instead.
+    class BodyComponent < JetUi::Dialog::BodyComponent
     end
   end
 end

--- a/app/components/jet_ui/modal/component.rb
+++ b/app/components/jet_ui/modal/component.rb
@@ -2,52 +2,22 @@
 
 module JetUi
   module Modal
-    class Component < JetUi::BaseComponent
-      SIZES = %w[sm md lg xl 2xl 3xl 4xl 5xl 6xl].freeze
-      DEFAULT_SIZE = '2xl'
-
-      def initialize(title: nil, subtitle: nil, size: DEFAULT_SIZE, id: nil)
-        @title = title
-        @subtitle = subtitle
-        @size = size
-        @id = id
+    # @deprecated Use {JetUi::Dialog::Component} with `position: :center` instead.
+    #   Kept as a thin shim so existing `jet_ui.modal(...)` calls and
+    #   `data: { turbo_frame: :modal }` links keep working. Will be removed in the next
+    #   major version.
+    class Component < JetUi::Dialog::Component
+      def self.deprecator
+        @deprecator ||= ActiveSupport::Deprecation.new('1.0', 'JetUi')
       end
 
-      erb_template <<~ERB
-        <%= container_tag do %>
-          <%= helpers.jet_ui.modal_header(title: @title, subtitle: @subtitle, closable: closable?, id: @id) %>
-          <%= content %>
-        <% end %>
-      ERB
-
-      private
-
-      def container_tag(&block)
-        return sync_dialog(&block) if @id
-        return turbo_frame_dialog(&block) if helpers.turbo_frame_request?
-
-        content_tag :div, class: class_names('modal modal-page', "w-#{@size}"), &block
-      end
-
-      def sync_dialog(&block)
-        dialog_tag(id: @id, data: { modals_target: 'dialog' }, &block)
-      end
-
-      def turbo_frame_dialog(&block)
-        helpers.turbo_frame_tag :modal do
-          dialog_tag(id: :modalDialog, data: { controller: 'modal' }) do
-            helpers.turbo_frame_tag(:modalContent, &block)
-          end
-        end
-      end
-
-      def dialog_tag(**options, &block)
-        attrs = { tabindex: '-1', class: class_names('modal', 'animate-slide-up', "w-#{@size}") }
-        content_tag :dialog, **attrs, **options, &block
-      end
-
-      def closable?
-        helpers.turbo_frame_request? || @id
+      def initialize(title: nil, subtitle: nil, size: JetUi::Dialog::Component::DEFAULT_SIZE, id: nil)
+        self.class.deprecator.warn(
+          'JetUi::Modal::Component is deprecated and will be removed in the next major ' \
+          'version. Use JetUi::Dialog::Component with position: :center instead ' \
+          '(jet_ui.dialog).'
+        )
+        super(title: title, subtitle: subtitle, position: :center, size: size, id: id)
       end
     end
   end

--- a/app/components/jet_ui/modal/footer_component.rb
+++ b/app/components/jet_ui/modal/footer_component.rb
@@ -2,44 +2,8 @@
 
 module JetUi
   module Modal
-    class FooterComponent < JetUi::BaseComponent
-      def initialize(direction: :row, align: :start, justify: :start, bordered: true, **options)
-        @direction = direction
-        @align = align
-        @justify = justify
-        @bordered = bordered
-        @options = options
-      end
-
-      def call
-        content_tag :div, content, class: classes, **@options.except(:class)
-      end
-
-      private
-
-      def classes
-        class_names(
-          'modal__footer',
-          { 'modal__footer-bordered' => @bordered },
-          direction_class,
-          align_class,
-          justify_class,
-          @options[:class]
-        )
-      end
-
-      def direction_class
-        { col: 'flex flex-col gap-2', row: 'flex flex-row gap-2' }[@direction]
-      end
-
-      def align_class
-        { start: 'items-start', center: 'items-center', end: 'items-end' }[@align]
-      end
-
-      def justify_class
-        { start: 'justify-start', center: 'justify-center', end: 'justify-end',
-          between: 'justify-between' }[@justify]
-      end
+    # @deprecated Use {JetUi::Dialog::FooterComponent} instead.
+    class FooterComponent < JetUi::Dialog::FooterComponent
     end
   end
 end

--- a/app/components/jet_ui/modal/header_component.rb
+++ b/app/components/jet_ui/modal/header_component.rb
@@ -2,44 +2,12 @@
 
 module JetUi
   module Modal
-    class HeaderComponent < JetUi::BaseComponent
-      def initialize(title: nil, subtitle: nil, closable: true, id: nil, bordered: true, **options)
-        @title = title
-        @subtitle = subtitle
-        @closable = closable
-        @id = id
-        @bordered = bordered
-        @options = options
-      end
-
-      erb_template <<~ERB
-        <div class="<%= classes %>">
-          <div>
-            <% if @title %>
-              <h3 class="modal__title"><%= @title %></h3>
-            <% end %>
-            <% if @subtitle %>
-              <div class="modal__subtitle"><%= @subtitle %></div>
-            <% end %>
-            <%= content %>
-          </div>
-
-          <% if @closable %>
-            <button type="button" class="modal__close" data-action="click->modal#close click->modals#close" aria-label="Close" data-id="<%= @id %>">
-              <%= helpers.jet_ui.icon("x-mark", size: 6) %>
-            </button>
-          <% end %>
-        </div>
-      ERB
-
-      private
-
-      def classes
-        class_names(
-          'modal__header',
-          { 'modal__header-bordered' => @bordered },
-          @options[:class]
-        )
+    # @deprecated Use {JetUi::Dialog::HeaderComponent} instead.
+    class HeaderComponent < JetUi::Dialog::HeaderComponent
+      # `id:` accepted and ignored for signature compatibility with the pre-deprecation API.
+      def initialize(title: nil, subtitle: nil, closable: true, id: nil, bordered: true, # rubocop:disable Lint/UnusedMethodArgument
+                     **options)
+        super(title: title, subtitle: subtitle, closable: closable, bordered: bordered, **options)
       end
     end
   end

--- a/app/components/jet_ui/turbo_confirm/component.html.erb
+++ b/app/components/jet_ui/turbo_confirm/component.html.erb
@@ -1,20 +1,18 @@
 <dialog id="turbo-confirm" tabindex="-1"
-        class="modal w-2xl animate-slide-up"
+        class="dialog dialog-center w-2xl"
         data-controller="turbo-confirm">
-  <form method="dialog">
-    <div class="modal__header modal__header-bordered">
-      <div>
-        <h3 class="modal__title">Are you absolutely sure?</h3>
-      </div>
-    </div>
+  <div class="dialog__panel">
+    <form method="dialog">
+      <%= helpers.jet_ui.dialog_header(title: 'Are you absolutely sure?', closable: false) %>
 
-    <div class="modal__body">
-      <p>This cannot be undone.</p>
-    </div>
+      <%= helpers.jet_ui.dialog_body do %>
+        <p>This cannot be undone.</p>
+      <% end %>
 
-    <div class="modal__footer modal__footer-bordered flex flex-row gap-2 items-start justify-end">
-      <%= helpers.jet_ui.btn "Cancel", type: :submit, variant: :outline, value: "cancel" %>
-      <%= helpers.jet_ui.btn "Yes, I'm sure", type: :submit, variant: :danger, value: "confirm" %>
-    </div>
-  </form>
+      <%= helpers.jet_ui.dialog_footer justify: :end do %>
+        <%= helpers.jet_ui.btn 'Cancel', type: :submit, variant: :outline, value: 'cancel' %>
+        <%= helpers.jet_ui.btn "Yes, I'm sure", type: :submit, variant: :danger, value: 'confirm' %>
+      <% end %>
+    </form>
+  </div>
 </dialog>

--- a/docs/components/dialog.md
+++ b/docs/components/dialog.md
@@ -1,0 +1,167 @@
+# Dialog
+
+Overlay component built on the native `<dialog>` element. Unifies what used to be separate
+`Modal` and `Drawer` components into one, with five positions: `:center` (modal-like) or
+`:left`/`:right`/`:top`/`:bottom` (drawer-like, sliding in from that edge).
+
+Supports two rendering modes:
+
+- **Async (Turbo Frame)** — open via a Turbo Frame request; the trigger links or forms use
+  `data: { turbo_frame: :dialog }`. The `<dialog>` shell is built client-side by
+  `DialogsController` before Turbo navigates the frame, so no ids need to be allocated by hand.
+- **Sync** — pass an `id:` and open it by dispatching a click on any element with
+  `data-action="click->dialogs#open" data-id="your-id"`.
+
+Any number of dialogs can be nested — opening a dialog from a link or button **inside** an
+already-open dialog stacks it on top; closing it returns focus to the one underneath. Only the
+bottom-most dialog dims the page.
+
+Requires Stimulus. Run `rails generate jet_ui:install` once to register the `dialog` and
+`dialogs` controllers automatically. Render `<%= jet_ui.dialogs %>` once in your layout — it
+mounts the stack manager's root and the sentinel Turbo Frame that async opens adopt.
+
+## Examples
+
+```erb
+<%# In your layout, once %>
+<%= jet_ui.dialogs %>
+
+<%# Async via Turbo Frame (in a partial loaded into the sentinel frame) %>
+<%= jet_ui.dialog(title: "Edit User") do %>
+  <%= jet_ui.dialog_body do %>
+    <%= render "form", user: @user %>
+  <% end %>
+  <%= jet_ui.dialog_footer do %>
+    <%= jet_ui.btn "Save", type: :submit, form: "edit_user_form" %>
+  <% end %>
+<% end %>
+
+<%# The trigger picks the position/size — the server response only knows its own content %>
+<%= jet_ui.btn "Edit", url: edit_user_path(user),
+      data: { turbo_frame: :dialog, dialog_position: :right, dialog_size: :lg } %>
+
+<%# Sync — button + pre-rendered dialog on the same page %>
+<button data-action="click->dialogs#open" data-id="confirm-dialog">Delete</button>
+
+<%= jet_ui.dialog(id: "confirm-dialog", title: "Are you sure?") do %>
+  <%= jet_ui.dialog_body { "This action cannot be undone." } %>
+  <%= jet_ui.dialog_footer justify: :end do %>
+    <%= jet_ui.btn "Cancel", variant: :outline, data: { action: "click->dialog#close" } %>
+    <%= jet_ui.btn "Delete", variant: :danger %>
+  <% end %>
+<% end %>
+
+<%# Nested — open a second dialog from a link/button inside the first %>
+<%= jet_ui.dialog(id: "level-1", title: "Level 1") do %>
+  <%= jet_ui.dialog_body do %>
+    <button data-action="click->dialogs#open" data-id="level-2">Open nested dialog</button>
+  <% end %>
+<% end %>
+
+<%= jet_ui.dialog(id: "level-2", title: "Level 2", position: :right) do %>
+  <%= jet_ui.dialog_body { "Stacks on top of level 1." } %>
+<% end %>
+
+<%# Custom size %>
+<%= jet_ui.dialog(title: "Wide dialog", size: "4xl") do %>
+  ...
+<% end %>
+```
+
+## Parameters
+
+### `dialog`
+
+| Parameter     | Type    | Default    | Description                                                                                  |
+|---------------|---------|------------|-----------------------------------------------------------------------------------------------|
+| `title`       | String  | `nil`      | Header title text.                                                                             |
+| `subtitle`    | String  | `nil`      | Header subtitle text.                                                                          |
+| `position`    | Symbol  | `:center`  | `:center`, `:left`, `:right`, `:top`, `:bottom`.                                               |
+| `size`        | String  | `'2xl'`    | `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`. Controls width for `:center`/`:left`/`:right`, height for `:top`/`:bottom`. |
+| `id`          | String  | `nil`      | Enables sync mode. Must match the `data-id` on the trigger.                                    |
+| `closable`    | Boolean | `true`     | Shows the × close button in the header.                                                        |
+| `dismissible` | Boolean | `true`     | Whether `Esc` and a backdrop click close the dialog. The close button always closes it.        |
+| `swipe`       | Boolean | `true`     | Swipe-to-dismiss on touch. Only applies to edge positions — ignored for `:center`.              |
+
+### `dialog_header`
+
+| Parameter  | Type    | Default | Description                          |
+|------------|---------|---------|---------------------------------------|
+| `title`    | String  | `nil`   | Title text.                           |
+| `subtitle` | String  | `nil`   | Subtitle text.                        |
+| `closable` | Boolean | `true`  | Shows the close button.               |
+| `bordered` | Boolean | `true`  | Adds a bottom border to the header.   |
+
+### `dialog_body`
+
+Wrapper for dialog content. Accepts `**options` (HTML attributes).
+
+### `dialog_footer`
+
+| Parameter   | Type   | Default  | Description                                             |
+|-------------|--------|----------|----------------------------------------------------------|
+| `direction` | Symbol | `:row`   | `:row` or `:col`.                                        |
+| `align`     | Symbol | `:start` | `:start`, `:center`, `:end`.                             |
+| `justify`   | Symbol | `:start` | `:start`, `:center`, `:end`, `:between`.                 |
+| `bordered`  | Boolean| `true`   | Adds a top border to the footer.                         |
+
+## Triggers
+
+**Async — position/size on the trigger:**
+
+```erb
+<%= jet_ui.btn "Edit", url: edit_post_path(post),
+      data: { turbo_frame: :dialog, dialog_position: :right, dialog_size: :lg } %>
+```
+
+**Sync — dialog markup already on the page:**
+
+```erb
+<button data-action="click->dialogs#open" data-id="my-dialog">Open</button>
+```
+
+## CSS classes
+
+| Class                      | Description                          |
+|----------------------------|---------------------------------------|
+| `.dialog`                  | Root dialog positioning shell         |
+| `.dialog-center`           | `:center` position                    |
+| `.dialog-left`             | `:left` position                      |
+| `.dialog-right`            | `:right` position                     |
+| `.dialog-top`              | `:top` position                       |
+| `.dialog-bottom`           | `:bottom` position                    |
+| `.dialog-page`             | Non-dialog inline variant             |
+| `.dialog__panel`           | Visible card (background, shadow, rounded corners, animation) |
+| `.dialog__header`          | Header area                           |
+| `.dialog__header-bordered` | Header with bottom border             |
+| `.dialog__title`           | Title `<h3>`                          |
+| `.dialog__subtitle`        | Subtitle element                      |
+| `.dialog__close`           | Close button                          |
+| `.dialog__body`            | Content area                          |
+| `.dialog__footer`          | Footer area                           |
+| `.dialog__footer-bordered` | Footer with top border                |
+
+## Migrating from Modal/Drawer
+
+`Modal` and `Drawer` are deprecated in favor of `Dialog` and will be removed in the next major
+version. Existing code keeps working — `jet_ui.modal(...)` and `jet_ui.drawer(...)` are thin
+shims that render a `Dialog` at `position: :center` / `position: :right` respectively, and emit
+an `ActiveSupport::Deprecation` warning.
+
+| Old                                          | New                                                        |
+|-----------------------------------------------|-------------------------------------------------------------|
+| `jet_ui.modal(...)`                            | `jet_ui.dialog(position: :center, ...)`                     |
+| `jet_ui.drawer(...)`                           | `jet_ui.dialog(position: :right, ...)`                      |
+| `jet_ui.modal_header/body/footer`              | `jet_ui.dialog_header/body/footer`                          |
+| `data: { turbo_frame: :modal }`                | still works — resolved to `:dialog`, presets `position: :center` |
+| `data: { turbo_frame: :drawer }`               | still works — resolved to `:dialog`, presets `position: :right`  |
+| `.modal__*` / `.drawer__*` CSS                 | `.dialog__*`                                                 |
+| `<%= turbo_frame_tag :modal %>` / `:drawer` in layout | `<%= jet_ui.dialogs %>` sentinel in layout            |
+| `data-controller="modals"` + `click->modals#open` | `data-action="click->dialogs#open"` (no wrapper controller needed) |
+| `data-controller="drawers"` + `click->drawers#open` | `data-action="click->dialogs#open"` (no wrapper controller needed) |
+
+The async `data-turbo-frame="modal"`/`"drawer"` aliases keep working automatically — no changes
+needed to existing async links. The old standalone `modal`/`modals`/`drawer`/`drawers` Stimulus
+controllers no longer match the markup rendered by the sync-mode shims (which now target
+`data-dialogs-target`); if you registered those controllers directly on custom markup, migrate
+your `data-controller` and `data-action` attributes to `dialogs`/`click->dialogs#open`.

--- a/docs/components/drawer.md
+++ b/docs/components/drawer.md
@@ -1,77 +1,25 @@
 # Drawer
 
-Slide-in panel component. Slides in from the right. Supports the same two rendering modes as Modal:
+> **Deprecated.** `Drawer` is now a thin shim around [`Dialog`](dialog.md) with
+> `position: :right`, and will be removed in the next major version. Existing
+> `jet_ui.drawer(...)` calls keep working and emit an `ActiveSupport::Deprecation` warning — see
+> [Migrating from Modal/Drawer](dialog.md#migrating-from-modaldrawer) for the full mapping,
+> including CSS classes and Stimulus wiring, both of which changed under the hood. New code
+> should use `jet_ui.dialog(position: :right, ...)` directly — or any of `:left`, `:top`,
+> `:bottom` for other edges, which Drawer never supported.
 
-- **Async (Turbo Frame)** — open via a Turbo Frame request; renders a `<turbo-frame id="drawer">` wrapping a `<dialog>` controlled by the `drawer` Stimulus controller.
-- **Sync** — pass an `id:` and place a `data-controller="drawers"` wrapper on the page; open by dispatching a click on any element with `data-action="click->drawers#open" data-id="your-id"`.
-
-Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
-
-## Examples
+## Example
 
 ```erb
-<%# Async via Turbo Frame %>
-<%= jet_ui.drawer(title: "User details") do %>
+<%= jet_ui.drawer(title: "User details", id: "user-details") do %>
   <%= jet_ui.drawer_body do %>
     <%= render "users/detail", user: @user %>
   <% end %>
-<% end %>
-
-<%# Sync %>
-<div data-controller="drawers">
-  <button data-action="click->drawers#open" data-id="filters-drawer">Filters</button>
-
-  <%= jet_ui.drawer(id: "filters-drawer", title: "Filters") do %>
-    <%= jet_ui.drawer_body do %>
-      <%= render "filters_form" %>
-    <% end %>
-    <%= jet_ui.drawer_footer do %>
-      <%= jet_ui.btn "Apply" %>
-    <% end %>
-  <% end %>
-</div>
-
-<%# Custom size %>
-<%= jet_ui.drawer(title: "Wide panel", size: "4xl") do %>
-  ...
 <% end %>
 ```
 
 ## Parameters
 
-### `drawer`
-
-| Parameter  | Type   | Default | Description                                                                                     |
-|------------|--------|---------|-------------------------------------------------------------------------------------------------|
-| `title`    | String | `nil`   | Header title text.                                                                              |
-| `subtitle` | String | `nil`   | Header subtitle text.                                                                           |
-| `size`     | String | `'2xl'` | Width token: `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.                       |
-| `id`       | String | `nil`   | Enables sync mode. Must match the `data-id` on the trigger button.                              |
-
-### `drawer_header`
-
-| Parameter  | Type    | Default | Description                                         |
-|------------|---------|---------|-----------------------------------------------------|
-| `title`    | String  | `nil`   | Title text.                                         |
-| `subtitle` | String  | `nil`   | Subtitle text.                                      |
-| `closable` | Boolean | `true`  | Shows the close button.                             |
-| `id`       | String  | `nil`   | Passed to the close button's `data-id` attribute.   |
-
-### `drawer_body`
-
-Wrapper for drawer content. Accepts `**options` (HTML attributes).
-
-### `drawer_footer`
-
-Wrapper for drawer actions. Accepts `**options` (HTML attributes).
-
-## CSS classes
-
-| Class            | Description                      |
-|------------------|----------------------------------|
-| `.drawer`        | Root dialog element              |
-| `.drawer__header`| Header area                      |
-| `.drawer__title` | Title `<h3>`                     |
-| `.drawer__close` | Close button                     |
-| `.drawer__body`  | Content area                     |
-| `.drawer__footer`| Footer area                      |
+Same as [`Dialog`](dialog.md#parameters), minus `position` (always `:right`).
+`drawer_header`/`drawer_body`/`drawer_footer` accept the same parameters as their `dialog_*`
+counterparts.

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,17 +1,16 @@
 # Modal
 
-Dialog overlay component. Supports two rendering modes:
+> **Deprecated.** `Modal` is now a thin shim around [`Dialog`](dialog.md) with
+> `position: :center`, and will be removed in the next major version. Existing
+> `jet_ui.modal(...)` calls keep working and emit an `ActiveSupport::Deprecation` warning — see
+> [Migrating from Modal/Drawer](dialog.md#migrating-from-modaldrawer) for the full mapping,
+> including CSS classes and Stimulus wiring, both of which changed under the hood. New code
+> should use `jet_ui.dialog(position: :center, ...)` directly.
 
-- **Async (Turbo Frame)** — open via a Turbo Frame request; the modal wraps itself in a `<turbo-frame id="modal">` and renders a `<dialog>` controlled by the `modal` Stimulus controller.
-- **Sync** — pass an `id:` and place a `data-controller="modals"` wrapper on the page; open by dispatching a click on any element with `data-action="click->modals#open" data-id="your-id"`.
-
-Requires Stimulus. Run `rails generate jet_ui:install` once to register the controller automatically.
-
-## Examples
+## Example
 
 ```erb
-<%# Async via Turbo Frame (in a partial loaded into turbo_frame_tag :modal) %>
-<%= jet_ui.modal(title: "Edit User") do %>
+<%= jet_ui.modal(title: "Edit User", id: "edit-user") do %>
   <%= jet_ui.modal_body do %>
     <%= render "form", user: @user %>
   <% end %>
@@ -19,67 +18,10 @@ Requires Stimulus. Run `rails generate jet_ui:install` once to register the cont
     <%= jet_ui.btn "Save", type: :submit, form: "edit_user_form" %>
   <% end %>
 <% end %>
-
-<%# Sync — button + pre-rendered dialog on the same page %>
-<div data-controller="modals">
-  <button data-action="click->modals#open" data-id="confirm-modal">Delete</button>
-
-  <%= jet_ui.modal(id: "confirm-modal", title: "Are you sure?") do %>
-    <%= jet_ui.modal_body { "This action cannot be undone." } %>
-    <%= jet_ui.modal_footer do %>
-      <%= jet_ui.btn "Cancel", variant: :outline,
-            data: { action: "click->modals#close", id: "confirm-modal" } %>
-      <%= jet_ui.btn "Delete", variant: :danger %>
-    <% end %>
-  <% end %>
-</div>
-
-<%# Custom size %>
-<%= jet_ui.modal(title: "Wide modal", size: "4xl") do %>
-  ...
-<% end %>
 ```
 
 ## Parameters
 
-### `modal`
-
-| Parameter  | Type   | Default | Description                                                                                     |
-|------------|--------|---------|-------------------------------------------------------------------------------------------------|
-| `title`    | String | `nil`   | Header title text.                                                                              |
-| `subtitle` | String | `nil`   | Header subtitle text.                                                                           |
-| `size`     | String | `'2xl'` | Max-width token: `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.                   |
-| `id`       | String | `nil`   | Enables sync mode. Must match the `data-id` on the trigger button.                              |
-
-### `modal_header`
-
-| Parameter  | Type    | Default | Description                                         |
-|------------|---------|---------|-----------------------------------------------------|
-| `title`    | String  | `nil`   | Title text.                                         |
-| `subtitle` | String  | `nil`   | Subtitle text.                                      |
-| `closable` | Boolean | `true`  | Shows the close button.                             |
-| `bordered` | Boolean | `true`  | Adds a bottom border to the header.                 |
-| `id`       | String  | `nil`   | Passed to the close button's `data-id` attribute.   |
-
-### `modal_body`
-
-Wrapper for modal content. Accepts `**options` (HTML attributes).
-
-### `modal_footer`
-
-Wrapper for modal actions. Accepts `**options` (HTML attributes).
-
-## CSS classes
-
-| Class                      | Description                    |
-|----------------------------|--------------------------------|
-| `.modal`                   | Root dialog/container element  |
-| `.modal-page`              | Non-dialog inline variant      |
-| `.modal__header`           | Header area                    |
-| `.modal__header-bordered`  | Header with bottom border      |
-| `.modal__title`            | Title `<h3>`                   |
-| `.modal__subtitle`         | Subtitle element               |
-| `.modal__close`            | Close button                   |
-| `.modal__body`             | Content area                   |
-| `.modal__footer`           | Footer area                    |
-| `.modal__footer-bordered`  | Footer with top border         |
+Same as [`Dialog`](dialog.md#parameters), minus `position` (always `:center`).
+`modal_header`/`modal_body`/`modal_footer` accept the same parameters as their `dialog_*`
+counterparts.

--- a/lib/generators/jet_ui/eject/eject_generator.rb
+++ b/lib/generators/jet_ui/eject/eject_generator.rb
@@ -237,6 +237,25 @@ module JetUi
             { src: 'test/components/previews/jet_ui/navbar/component_preview.rb',                               dest: 'test/components/previews/jet_ui/navbar/component_preview.rb',           type: :preview }
           ]
         },
+        'dialog' => {
+          files: [
+            { src: 'app/components/jet_ui/dialog/component.rb',                                                   dest: 'app/components/jet_ui/dialog/component.rb' },
+            { src: 'app/components/jet_ui/dialog/header_component.rb',                                            dest: 'app/components/jet_ui/dialog/header_component.rb' },
+            { src: 'app/components/jet_ui/dialog/body_component.rb',                                              dest: 'app/components/jet_ui/dialog/body_component.rb' },
+            { src: 'app/components/jet_ui/dialog/footer_component.rb',                                            dest: 'app/components/jet_ui/dialog/footer_component.rb' },
+            { src: 'app/assets/stylesheets/jet_ui/dialog.css',                                                    dest: 'app/assets/stylesheets/jet_ui/dialog.css' },
+            { src: 'app/assets/javascripts/jet_ui/dialog_controller.js',                                          dest: 'app/assets/javascripts/jet_ui/dialog_controller.js',                    type: :javascript },
+            { src: 'app/assets/javascripts/jet_ui/dialogs_controller.js',                                         dest: 'app/assets/javascripts/jet_ui/dialogs_controller.js',                   type: :javascript },
+            { src: 'test/components/jet_ui/dialog/component_test.rb',                                             dest: 'test/components/jet_ui/dialog/component_test.rb',                       type: :test },
+            { src: 'test/components/previews/jet_ui/dialog/component_preview.rb',                                 dest: 'test/components/previews/jet_ui/dialog/component_preview.rb',           type: :preview }
+          ]
+        },
+        'dialogs' => {
+          files: [
+            { src: 'app/components/jet_ui/dialogs/component.rb',                                                  dest: 'app/components/jet_ui/dialogs/component.rb' },
+            { src: 'test/components/jet_ui/dialogs/component_test.rb',                                            dest: 'test/components/jet_ui/dialogs/component_test.rb', type: :test }
+          ]
+        },
         'modal' => {
           files: [
             { src: 'app/components/jet_ui/modal/component.rb',                                                  dest: 'app/components/jet_ui/modal/component.rb' },

--- a/lib/generators/jet_ui/install/install_generator.rb
+++ b/lib/generators/jet_ui/install/install_generator.rb
@@ -146,9 +146,9 @@ module JetUi
         install_npm_package
         say '  Ensure @hotwired/stimulus is installed — it is a peer dependency the controllers import.', :yellow
         say '  Register the controllers you use, in your Stimulus controllers index:'
-        say %(    import { ModalController, DrawerController } from "#{NPM_PACKAGE}")
-        say %(    application.register("modal", ModalController))
-        say %(    application.register("drawer", DrawerController))
+        say %(    import { DialogController, DialogsController } from "#{NPM_PACKAGE}")
+        say %(    application.register("dialog", DialogController))
+        say %(    application.register("dialogs", DialogsController))
         say '  Import the styles, in your Tailwind/CSS entry point:'
         say %(    @import "#{NPM_PACKAGE}/css";)
       end

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 import ClipboardController from '../app/assets/javascripts/jet_ui/clipboard_controller.js'
+import DialogController from '../app/assets/javascripts/jet_ui/dialog_controller.js'
+import DialogsController from '../app/assets/javascripts/jet_ui/dialogs_controller.js'
 import DrawerController from '../app/assets/javascripts/jet_ui/drawer_controller.js'
 import DrawersController from '../app/assets/javascripts/jet_ui/drawers_controller.js'
 import DropdownController from '../app/assets/javascripts/jet_ui/dropdown_controller.js'
@@ -11,6 +13,8 @@ import TurboConfirmController from '../app/assets/javascripts/jet_ui/turbo_confi
 
 export {
   ClipboardController,
+  DialogController,
+  DialogsController,
   DrawerController,
   DrawersController,
   DropdownController,

--- a/test/components/jet_ui/dialog/component_test.rb
+++ b/test/components/jet_ui/dialog/component_test.rb
@@ -30,6 +30,13 @@ class JetUi::Dialog::ComponentTest < ViewComponent::TestCase
     assert_selector 'dialog[data-dialog-swipe-value="true"]'
   end
 
+  def test_position_value_serializes_without_symbol_colon
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :left))
+
+    # Regression guard: Stimulus reads this value as a plain string ("left"), not ":left".
+    assert_selector 'dialog[data-dialog-position-value="left"]'
+  end
+
   def test_position_right
     render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :right))
 

--- a/test/components/jet_ui/dialog/component_test.rb
+++ b/test/components/jet_ui/dialog/component_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Dialog::ComponentTest < ViewComponent::TestCase
+  def test_renders_sync_dialog_with_id
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog'))
+
+    assert_selector 'dialog#my-dialog'
+    assert_selector 'dialog[data-dialogs-target="dialog"]'
+  end
+
+  def test_renders_div_without_id_outside_turbo_frame
+    render_inline(JetUi::Dialog::Component.new)
+
+    assert_selector 'div.dialog-page'
+    assert_no_selector 'dialog'
+  end
+
+  def test_default_position_is_center
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog'))
+
+    assert_selector 'dialog.dialog-center'
+  end
+
+  def test_position_left
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :left))
+
+    assert_selector 'dialog.dialog-left'
+    assert_selector 'dialog[data-dialog-swipe-value="true"]'
+  end
+
+  def test_position_right
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :right))
+
+    assert_selector 'dialog.dialog-right'
+  end
+
+  def test_position_top
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :top))
+
+    assert_selector 'dialog.dialog-top'
+    assert_selector 'dialog.h-2xl'
+  end
+
+  def test_position_bottom
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :bottom))
+
+    assert_selector 'dialog.dialog-bottom'
+  end
+
+  def test_center_position_disables_swipe
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', position: :center, swipe: true))
+
+    assert_selector 'dialog[data-dialog-swipe-value="false"]'
+  end
+
+  def test_size_controls_width_for_vertical_positions
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', size: 'lg'))
+
+    assert_selector 'dialog.w-lg'
+  end
+
+  def test_dismissible_value_defaults_true
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog'))
+
+    assert_selector 'dialog[data-dialog-dismissible-value="true"]'
+  end
+
+  def test_dismissible_can_be_disabled
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog', dismissible: false))
+
+    assert_selector 'dialog[data-dialog-dismissible-value="false"]'
+  end
+
+  def test_has_flash_slot
+    render_inline(JetUi::Dialog::Component.new(id: 'my-dialog'))
+
+    assert_selector 'div.dialog__flash-slot'
+  end
+
+  def test_header_renders_title
+    render_inline(JetUi::Dialog::HeaderComponent.new(title: 'My Dialog'))
+
+    assert_selector 'h3.dialog__title'
+    assert_text 'My Dialog'
+  end
+
+  def test_header_renders_subtitle
+    render_inline(JetUi::Dialog::HeaderComponent.new(subtitle: 'Subtitle'))
+
+    assert_selector 'div.dialog__subtitle'
+    assert_text 'Subtitle'
+  end
+
+  def test_closable_header_has_close_button
+    render_inline(JetUi::Dialog::HeaderComponent.new(closable: true))
+
+    assert_selector 'button.dialog__close'
+  end
+
+  def test_non_closable_header_has_no_close_button
+    render_inline(JetUi::Dialog::HeaderComponent.new(closable: false))
+
+    assert_no_selector 'button.dialog__close'
+  end
+
+  def test_header_bordered_by_default
+    render_inline(JetUi::Dialog::HeaderComponent.new)
+
+    assert_selector 'div.dialog__header-bordered'
+  end
+
+  def test_body_renders_div
+    render_inline(JetUi::Dialog::BodyComponent.new) { 'Body content' }
+
+    assert_selector 'div.dialog__body'
+    assert_text 'Body content'
+  end
+
+  def test_footer_renders_div
+    render_inline(JetUi::Dialog::FooterComponent.new) { 'Footer' }
+
+    assert_selector 'div.dialog__footer'
+  end
+
+  def test_footer_bordered_by_default
+    render_inline(JetUi::Dialog::FooterComponent.new) { 'Footer' }
+
+    assert_selector 'div.dialog__footer-bordered'
+  end
+
+  def test_footer_justify_end
+    render_inline(JetUi::Dialog::FooterComponent.new(justify: :end)) { 'Footer' }
+
+    assert_selector 'div.justify-end'
+  end
+end

--- a/test/components/jet_ui/dialogs/component_test.rb
+++ b/test/components/jet_ui/dialogs/component_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class JetUi::Dialogs::ComponentTest < ViewComponent::TestCase
+  def test_renders_root_mount_point
+    render_inline(JetUi::Dialogs::Component.new)
+
+    assert_selector 'div#dialogs[data-dialogs-target="root"]'
+  end
+
+  def test_renders_sentinel_turbo_frame
+    render_inline(JetUi::Dialogs::Component.new)
+
+    assert_selector 'turbo-frame#dialog[data-dialogs-target="sentinel"]'
+  end
+
+  def test_root_is_turbo_permanent_and_not_cached
+    render_inline(JetUi::Dialogs::Component.new)
+
+    assert_selector 'div#dialogs[data-turbo-permanent][data-turbo-cache="false"]'
+  end
+end

--- a/test/components/jet_ui/drawer/component_test.rb
+++ b/test/components/jet_ui/drawer/component_test.rb
@@ -3,62 +3,51 @@
 require 'test_helper'
 
 class JetUi::Drawer::ComponentTest < ViewComponent::TestCase
-  def test_renders_sync_dialog_with_id
-    render_inline(JetUi::Drawer::Component.new(id: 'my-drawer'))
+  include ActiveSupport::Testing::Deprecation
 
-    assert_selector 'dialog#my-drawer'
-    assert_selector 'dialog[data-drawers-target="dialog"]'
+  def test_emits_deprecation_warning
+    assert_deprecated(/JetUi::Drawer::Component is deprecated/, JetUi::Drawer::Component.deprecator) do
+      render_inline(JetUi::Drawer::Component.new(id: 'my-drawer'))
+    end
   end
 
-  def test_renders_div_without_id_outside_turbo_frame
-    render_inline(JetUi::Drawer::Component.new)
+  def test_renders_as_a_right_positioned_dialog
+    render_inline_without_deprecation { JetUi::Drawer::Component.new(id: 'my-drawer') }
 
-    assert_selector 'div.bg-background'
+    assert_selector 'dialog#my-drawer.dialog-right'
+    assert_selector 'dialog[data-dialogs-target="dialog"]'
+  end
+
+  def test_renders_page_variant_without_id_outside_turbo_frame
+    render_inline_without_deprecation { JetUi::Drawer::Component.new }
+
+    assert_selector 'div.dialog-page'
     assert_no_selector 'dialog'
   end
 
   def test_header_renders_title
     render_inline(JetUi::Drawer::HeaderComponent.new(title: 'My Drawer'))
 
-    assert_selector 'h3.drawer__title'
+    assert_selector 'h3.dialog__title'
     assert_text 'My Drawer'
   end
 
-  def test_header_renders_subtitle
-    render_inline(JetUi::Drawer::HeaderComponent.new(subtitle: 'Info'))
-
-    assert_selector 'div.drawer__subtitle'
-    assert_text 'Info'
-  end
-
-  def test_closable_header_has_close_button
-    render_inline(JetUi::Drawer::HeaderComponent.new(closable: true))
-
-    assert_selector 'button.drawer__close'
-  end
-
-  def test_non_closable_header_omits_close_button
-    render_inline(JetUi::Drawer::HeaderComponent.new(closable: false))
-
-    assert_no_selector 'button.drawer__close'
-  end
-
   def test_body_renders_div
-    render_inline(JetUi::Drawer::BodyComponent.new) { 'Body' }
+    render_inline(JetUi::Drawer::BodyComponent.new) { 'Body content' }
 
-    assert_selector 'div.drawer__body'
-    assert_text 'Body'
+    assert_selector 'div.dialog__body'
+    assert_text 'Body content'
   end
 
   def test_footer_renders_div
     render_inline(JetUi::Drawer::FooterComponent.new) { 'Footer' }
 
-    assert_selector 'div.drawer__footer'
+    assert_selector 'div.dialog__footer'
   end
 
-  def test_footer_bordered_by_default
-    render_inline(JetUi::Drawer::FooterComponent.new) { 'Footer' }
+  private
 
-    assert_selector 'div.drawer__footer-bordered'
+  def render_inline_without_deprecation(&block)
+    JetUi::Drawer::Component.deprecator.silence { render_inline(block.call) }
   end
 end

--- a/test/components/jet_ui/modal/component_test.rb
+++ b/test/components/jet_ui/modal/component_test.rb
@@ -3,74 +3,57 @@
 require 'test_helper'
 
 class JetUi::Modal::ComponentTest < ViewComponent::TestCase
-  def test_renders_sync_dialog_with_id
-    render_inline(JetUi::Modal::Component.new(id: 'my-modal'))
+  include ActiveSupport::Testing::Deprecation
 
-    assert_selector 'dialog#my-modal'
-    assert_selector 'dialog[data-modals-target="dialog"]'
+  def test_emits_deprecation_warning
+    assert_deprecated(/JetUi::Modal::Component is deprecated/, JetUi::Modal::Component.deprecator) do
+      render_inline(JetUi::Modal::Component.new(id: 'my-modal'))
+    end
   end
 
-  def test_renders_div_without_id_outside_turbo_frame
-    render_inline(JetUi::Modal::Component.new)
+  def test_renders_as_a_centered_dialog
+    render_inline_without_deprecation { JetUi::Modal::Component.new(id: 'my-modal') }
 
-    assert_selector 'div.modal'
+    assert_selector 'dialog#my-modal.dialog-center'
+    assert_selector 'dialog[data-dialogs-target="dialog"]'
+  end
+
+  def test_renders_page_variant_without_id_outside_turbo_frame
+    render_inline_without_deprecation { JetUi::Modal::Component.new }
+
+    assert_selector 'div.dialog-page'
     assert_no_selector 'dialog'
   end
 
   def test_header_renders_title
     render_inline(JetUi::Modal::HeaderComponent.new(title: 'My Modal'))
 
-    assert_selector 'h3.modal__title'
+    assert_selector 'h3.dialog__title'
     assert_text 'My Modal'
   end
 
-  def test_header_renders_subtitle
-    render_inline(JetUi::Modal::HeaderComponent.new(subtitle: 'Subtitle'))
+  def test_header_accepts_legacy_id_param
+    render_inline(JetUi::Modal::HeaderComponent.new(title: 'My Modal', id: 'ignored'))
 
-    assert_selector 'div.modal__subtitle'
-    assert_text 'Subtitle'
-  end
-
-  def test_closable_header_has_close_button
-    render_inline(JetUi::Modal::HeaderComponent.new(closable: true))
-
-    assert_selector 'button.modal__close'
-  end
-
-  def test_non_closable_header_has_no_close_button
-    render_inline(JetUi::Modal::HeaderComponent.new(closable: false))
-
-    assert_no_selector 'button.modal__close'
-  end
-
-  def test_header_bordered_by_default
-    render_inline(JetUi::Modal::HeaderComponent.new)
-
-    assert_selector 'div.modal__header-bordered'
+    assert_selector 'h3.dialog__title'
   end
 
   def test_body_renders_div
     render_inline(JetUi::Modal::BodyComponent.new) { 'Body content' }
 
-    assert_selector 'div.modal__body'
+    assert_selector 'div.dialog__body'
     assert_text 'Body content'
   end
 
   def test_footer_renders_div
     render_inline(JetUi::Modal::FooterComponent.new) { 'Footer' }
 
-    assert_selector 'div.modal__footer'
+    assert_selector 'div.dialog__footer'
   end
 
-  def test_footer_bordered_by_default
-    render_inline(JetUi::Modal::FooterComponent.new) { 'Footer' }
+  private
 
-    assert_selector 'div.modal__footer-bordered'
-  end
-
-  def test_footer_justify_end
-    render_inline(JetUi::Modal::FooterComponent.new(justify: :end)) { 'Footer' }
-
-    assert_selector 'div.justify-end'
+  def render_inline_without_deprecation(&block)
+    JetUi::Modal::Component.deprecator.silence { render_inline(block.call) }
   end
 end

--- a/test/components/jet_ui/turbo_confirm/component_test.rb
+++ b/test/components/jet_ui/turbo_confirm/component_test.rb
@@ -34,9 +34,9 @@ class JetUi::TurboConfirm::ComponentTest < ViewComponent::TestCase
     assert_selector 'button[value="confirm"]'
   end
 
-  def test_has_modal_classes
+  def test_has_dialog_classes
     render_inline(JetUi::TurboConfirm::Component.new)
 
-    assert_selector 'dialog.modal'
+    assert_selector 'dialog.dialog.dialog-center'
   end
 end

--- a/test/components/previews/jet_ui/dialog/component_preview.rb
+++ b/test/components/previews/jet_ui/dialog/component_preview.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class JetUi::Dialog::ComponentPreview < ViewComponent::Preview
+  def sync_centered
+    render JetUi::Dialog::Component.new(title: 'Dialog Title', subtitle: 'Subtitle', id: 'preview-dialog') do
+      render(JetUi::Dialog::BodyComponent.new) { 'Dialog content goes here.' }
+      render(JetUi::Dialog::FooterComponent.new(justify: :end)) do
+        render(JetUi::Btn::Component.new(variant: :secondary)) { 'Cancel' }
+        render(JetUi::Btn::Component.new) { 'Confirm' }
+      end
+    end
+  end
+
+  def position_right
+    render JetUi::Dialog::Component.new(title: 'Right Dialog', position: :right, id: 'preview-dialog-right') do
+      render(JetUi::Dialog::BodyComponent.new) { 'Slides in from the right, like the former Drawer.' }
+    end
+  end
+
+  def position_left
+    render JetUi::Dialog::Component.new(title: 'Left Dialog', position: :left, id: 'preview-dialog-left') do
+      render(JetUi::Dialog::BodyComponent.new) { 'Slides in from the left.' }
+    end
+  end
+
+  def position_top
+    render JetUi::Dialog::Component.new(title: 'Top Dialog', position: :top, size: 'sm', id: 'preview-dialog-top') do
+      render(JetUi::Dialog::BodyComponent.new) { 'Slides in from the top.' }
+    end
+  end
+
+  def position_bottom
+    render JetUi::Dialog::Component.new(title: 'Bottom Dialog', position: :bottom, size: 'sm', id: 'preview-dialog-bottom') do
+      render(JetUi::Dialog::BodyComponent.new) { 'Slides in from the bottom.' }
+    end
+  end
+
+  def header_only
+    render JetUi::Dialog::HeaderComponent.new(title: 'Header Title', subtitle: 'Header subtitle')
+  end
+
+  def body
+    render JetUi::Dialog::BodyComponent.new do
+      'Body content'
+    end
+  end
+
+  def footer_end
+    render JetUi::Dialog::FooterComponent.new(justify: :end) do
+      render(JetUi::Btn::Component.new(variant: :outline)) { 'Cancel' }
+      render(JetUi::Btn::Component.new) { 'Save' }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Replaces the separate `Modal` and `Drawer` components with a single `JetUi::Dialog::Component`, built on the native `<dialog>` element, supporting five positions: `:center` (modal-like), `:left`/`:right`/`:top`/`:bottom` (drawer-like). Any number of dialogs can be nested — opening one from inside another stacks it on top, and closing it restores the one underneath.

Implements #12. Reference implementation already shipped in jetrockets/ui.jetrockets.com PR #54; this port keeps `Modal`/`Drawer` as deprecated shims instead of deleting them outright, since jet_ui is a published gem with real external users.

## Status — all phases complete

- [x] **Phase 1** — Dialog core: `Dialog::Component` + Header/Body/Footer, `Dialogs::Component` mount point, CSS, `dialog_controller.js` + `dialogs_controller.js` (stack manager with sentinel-frame adoption for unlimited nesting, flash portal, deprecated `modal`/`drawer` frame-name aliases)
- [x] **Phase 2** — Deprecation shims: `Modal`/`Drawer::Component` as thin subclasses of `Dialog` with `ActiveSupport::Deprecation`; legacy standalone JS controllers marked deprecated with migration notes
- [x] **Phase 3** — Flash (no changes needed, already compatible) & TurboConfirm (migrated to Dialog sub-components)
- [x] **Phase 4** — Generators: eject manifest entries for `dialog`/`dialogs`, ViewComponent preview, Vite registration example updated
- [x] **Phase 5** — Docs (`docs/components/dialog.md` + deprecation notes in modal.md/drawer.md), README components table, CHANGELOG entry
- [x] **Phase 6** — Final validation: full local test suite (387 tests) + RuboCop clean before every push; found and fixed a real bug during self-review (legacy `data-turbo-frame="drawer"` triggers losing their aliased position after the first open — see the `fix(dialog)` commit)

All 22 CI checks green (Ruby 3.0–4.0 × Rails 7.0–8.1, RuboCop, Security audit, gem build, Version sync, Generators smoke test).

Commits are granular by responsibility, not one per phase — each push was validated locally before landing.

## What to review

- The sentinel-frame adoption mechanism in `dialogs_controller.js` (`#interceptTrigger`) — this is the trickiest part, worth a close look
- The Modal/Drawer deprecation shims (`app/components/jet_ui/{modal,drawer}/`) — confirm the migration story in `docs/components/dialog.md#migrating-from-modaldrawer` is complete
- Whether the legacy standalone `modal`/`modals`/`drawer`/`drawers` JS controllers should be removed now or kept deprecated until the next major (currently: kept, documented as no longer matching the new sync-mode markup)