### PR TITLE
docs: add Vite guide, drop redundant badges, reorganize Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,35 +17,41 @@ ViewComponent-based UI library for Rails applications, matching the design syste
 
 ## Installation
 
-Add to your Gemfile:
+Add the gem to your Gemfile, then run the install generator — it detects how your app manages
+JavaScript and wires jet_ui up accordingly, no flags needed:
 
 ```ruby
 gem "jet_ui"
 ```
-
-Run the install generator:
 
 ```bash
 bundle install
 rails generate jet_ui:install
 ```
 
-The generator:
-- Detects your Tailwind CSS source file and injects a single import covering all component stylesheets
-- Registers JetUi Stimulus controllers in your app's controllers index
+|              | Importmap                                                        | Vite                                                                          |
+|--------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| **Detected by**  | `config/importmap.rb` present                                  | a Vite config, or `vite` in `package.json`                                      |
+| **JS wiring**    | Automatic — controllers auto-register                          | Manual — you `import` and `application.register(...)` the ones you use          |
+| **CSS wiring**   | Automatic — injected into your Tailwind source                 | Manual — `@import "@jetrockets/jet_ui/css"` in your CSS entry point             |
+| **npm install**  | None needed — the gem ships the controllers itself              | Done for you by the generator (`yarn add @jetrockets/jet_ui`, or your package manager's equivalent) |
 
-When the gem is updated, both CSS and JS are picked up automatically — no further changes needed. Safe to re-run after upgrades.
+Full walkthrough and troubleshooting for the Vite path: [docs/vite.md](docs/vite.md).
 
-### Alternative: npm package (Vite)
+### Importmap
 
-The above (importmap) setup needs no npm install — the gem ships the controllers itself. If your app bundles JavaScript with Vite instead, run the install generator: it detects Vite, **installs the `@jetrockets/jet_ui` npm package** for you (running `yarn add @jetrockets/jet_ui`, or the npm/pnpm/bun equivalent it detects), and prints the wiring steps:
+The generator detects your Tailwind CSS source file and injects a single import covering all
+component stylesheets, and registers JetUi Stimulus controllers in your app's controllers index.
+When the gem is updated, both CSS and JS are picked up automatically — no further changes needed.
+Safe to re-run after upgrades.
 
-```bash
-rails generate jet_ui:install
-# detects Vite → runs: yarn add @jetrockets/jet_ui
-```
+### Vite
 
-Then register the controllers you use (`@hotwired/stimulus` is a peer dependency):
+The generator detects Vite and installs the `@jetrockets/jet_ui` npm package for you. Vite apps
+own their JS/CSS entry points, so those are not modified automatically — wire up the two pieces
+yourself:
+
+Register the controllers you use (`@hotwired/stimulus` is a peer dependency):
 
 ```javascript
 import { ModalController } from "@jetrockets/jet_ui"
@@ -65,6 +71,8 @@ Or, if you'd rather manage styles through the bundler than the Rails asset pipel
 import "@jetrockets/jet_ui/css"          // all component styles
 import "@jetrockets/jet_ui/css/btn.css"  // a single component
 ```
+
+See [docs/vite.md](docs/vite.md) for detection details and troubleshooting.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Checks](https://img.shields.io/github/actions/workflow/status/jetrockets/jet_ui/ci.yml?label=checks&logo=github)](https://github.com/jetrockets/jet_ui/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE.md)
 [![Downloads](https://img.shields.io/gem/dt/jet_ui)](https://rubygems.org/gems/jet_ui)
-[![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.0-CC342D)](https://rubygems.org/gems/jet_ui)
-[![Rails](https://img.shields.io/badge/rails-%3E%3D%207.0-CC0000)](https://rubygems.org/gems/jet_ui)
 [![Stars](https://img.shields.io/github/stars/jetrockets/jet_ui?style=social)](https://github.com/jetrockets/jet_ui/stargazers)
 
 ViewComponent-based UI library for Rails applications, matching the design system at [ui.jetrockets.com](https://ui.jetrockets.com).

--- a/docs/vite.md
+++ b/docs/vite.md
@@ -1,0 +1,131 @@
+# Using jet_ui with Vite
+
+jet_ui ships two ways to wire up its Stimulus controllers and CSS: the gem itself (for importmap
+apps) and an npm package, `@jetrockets/jet_ui` (for Vite apps). This guide covers the Vite path in
+detail — setup, what the install generator does and doesn't touch, and troubleshooting.
+
+If your app uses importmap instead, see the [README](../README.md#installation) — you don't need
+this guide.
+
+## How the generator detects Vite
+
+`rails generate jet_ui:install` doesn't ask which bundler you use — it detects it. The logic (see
+[`lib/generators/jet_ui/js_runtime.rb`](../lib/generators/jet_ui/js_runtime.rb)) is:
+
+1. **Vite wins if any of these exist**, checked in your app's root:
+   - `vite.config.js`, `vite.config.mjs`, or `vite.config.ts`
+   - `config/vite.json`
+   - `vite` listed under `dependencies` or `devDependencies` in `package.json`
+2. Otherwise, **importmap wins if `config/importmap.rb` exists**.
+3. If neither is found, the generator can't tell — it prints instructions for both and does
+   nothing automatically.
+
+Vite is checked first on purpose: a real Vite config is a stronger signal than a leftover
+`config/importmap.rb` from `rails new`, which is common in apps mid-migration to Vite.
+
+## Setup
+
+Run the install generator — it detects Vite and installs the npm package for you:
+
+```bash
+rails generate jet_ui:install
+```
+
+This runs the install command for whichever package manager your app uses (see
+[Package manager detection](#package-manager-detection) below) — equivalent to:
+
+```bash
+yarn add @jetrockets/jet_ui   # or npm/pnpm/bun, whichever the generator picked
+```
+
+Vite apps own their JS and CSS entry points, so **the generator does not touch them** — you wire
+up the two remaining pieces yourself:
+
+**1. Register the Stimulus controllers you use** (`@hotwired/stimulus` is a peer dependency, so
+it must already be in your `package.json`):
+
+```javascript
+import { ModalController } from "@jetrockets/jet_ui"
+
+application.register("modal", ModalController)
+```
+
+Only register the controllers your app actually uses — see each component's doc under
+[`docs/components/`](components/) for which controller it needs.
+
+**2. Import the component styles** in your Tailwind/CSS entry point:
+
+```css
+@import "@jetrockets/jet_ui/css";
+```
+
+Or, if you'd rather pull CSS in from JavaScript instead of your CSS entry point:
+
+```javascript
+import "@jetrockets/jet_ui/css"          // all component styles
+import "@jetrockets/jet_ui/css/btn.css"  // a single component, to keep the bundle lean
+```
+
+### Package manager detection
+
+The generator picks a package manager by checking, in order: `bun.lockb`, `pnpm-lock.yaml`,
+`yarn.lock`, `package-lock.json`, then the `"packageManager"` field in `package.json` (set by
+Corepack, e.g. `"yarn@4.5.0"` — useful on a fresh clone with no lockfile yet). If none of those
+match, it defaults to npm.
+
+Pass `--skip-install` to print the install command instead of running it (useful in CI, or if you
+want to review the command first):
+
+```bash
+rails generate jet_ui:install --skip-install
+```
+
+## Troubleshooting
+
+### The generator wired importmap, but my app uses Vite
+
+This means none of the Vite signals in [How detection works](#how-the-generator-detects-vite)
+were found. The most common cause: your `vite.config.js` exists but Vite isn't listed in
+`package.json` yet (e.g. it's a transitive dependency of `vite_rails`/`vite_ruby`, not a direct
+one) — check that `vite.config.js`/`.mjs`/`.ts` actually exists at your app's root, not nested in
+a subdirectory. If it does and detection still picks importmap, please
+[open an issue](https://github.com/jetrockets/jet_ui/issues/new) with your `vite.config.*`
+filename and where it lives — that's a detection gap worth fixing.
+
+### The generator installed the package with the wrong tool (e.g. npm instead of yarn)
+
+The package-manager detection only looks at lockfiles and the `packageManager` field — it doesn't
+read your global npm/yarn/pnpm preference. Make sure the lockfile for your preferred manager
+exists in the app root (run your manager's install command once to generate it) before running
+`jet_ui:install` again, or just run the install command yourself:
+
+```bash
+yarn add @jetrockets/jet_ui
+```
+
+### Controllers aren't registering / "X is not defined" in the console
+
+Two common causes:
+
+- **The controller name doesn't match.** `application.register("dialog", DialogController)` — the
+  string must match the `data-controller="dialog"` value the component renders. Check the
+  component's doc for the exact name.
+- **`@hotwired/stimulus` isn't installed.** It's a peer dependency — jet_ui's controllers `import`
+  from it directly, so it must be a real dependency of your app, not something jet_ui bundles for
+  you.
+
+### Styles aren't applied
+
+Confirm `@import "@jetrockets/jet_ui/css";` is actually in the file your build processes as CSS
+entry point (not, for example, a `.css` file that isn't `@import`-ed from your main stylesheet).
+If you're using per-component imports (`@jetrockets/jet_ui/css/btn.css`), make sure you imported
+one for every component you use — unlike the importmap path, nothing pulls all styles in
+automatically once you've switched to per-component imports.
+
+### Switching an existing importmap app to Vite
+
+Re-run the generator after adding a Vite config — it re-detects and switches to the Vite
+instructions. It won't undo anything the importmap path already wired into
+`app/javascript/controllers/index.js` or your Tailwind source; remove
+`eagerLoadControllersFrom("jet_ui", application)` and the `@import` of the gem's `jet_ui.css`
+manually once you've confirmed the Vite path works, to avoid loading jet_ui's CSS/JS twice.


### PR DESCRIPTION
## Summary

- Adds `docs/vite.md` — full setup and troubleshooting guide for the Vite/npm install path (detection logic, package manager detection, manual wiring steps, common troubleshooting scenarios)
- Drops the `Ruby >=`/`Rails >=` badges — duplicated info already in `## Requirements`, and not a pattern followed by comparable Ruby gems (checked ViewComponent, Devise, Simple Form, Sidekiq, RuboCop — none use version badges)
- Reorganizes `## Installation` with a comparison table so Importmap and Vite get equal visual weight, instead of Vite being a subordinate "Alternative:" section

Docs-only change, no code touched.